### PR TITLE
[Build-System] fallback to libtiff-4 on apple m1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -543,7 +543,7 @@ if test "$enable_builtin_tiff" = "yes" ; then
     AC_DEFINE([HAVE_LIBTIFF], [1], [Define to 1 if you have the `tiff' library (-ltiff).])
 else
     AC_CHECK_HEADERS([tiffio.h])
-    AC_CHECK_LIB([tiff], [TIFFOpen], , AC_MSG_ERROR("Cannot build without libtiff (does your system require a libtiff-devel package?)"), -lm)
+    AC_CHECK_LIB([tiff], [TIFFOpen], , AC_CHECK_LIB([libtiff-4], [TIFFOpen], , AC_MSG_ERROR("Cannot build without libtiff (does your system require a libtiff-devel package?)"), -lm), -lm)
 fi
 
 AC_CHECK_LIB([tiff], [TIFFCreateCustomDirectory], [


### PR DESCRIPTION
it builds for me on m1

```
CFLAGS="-I/opt/homebrew/Cellar/libtiff/4.4.0_1/include -I/opt/homebrew/Cellar/jpeg/9e/include" LDFLAGS="-L/opt/homebrew/Cellar/libtiff/4.4.0_1/lib -L/opt/homebrew/Cellar/jpeg/9e/lib" ./configure
```