### PR TITLE
Add checks for _M_ARM64

### DIFF
--- a/src/spandsp/fast_convert.h
+++ b/src/spandsp/fast_convert.h
@@ -314,7 +314,7 @@ extern "C"
         };
         return i;
     }
-#elif defined(_M_X64)
+#elif defined(_M_X64) || defined(_M_ARM64)
     /* Visual Studio x86_64 */
     /* x86_64 machines will do best with a simple assignment. */
 #include <intrin.h>

--- a/src/spandsp/telephony.h
+++ b/src/spandsp/telephony.h
@@ -26,7 +26,7 @@
 #if !defined(_SPANDSP_TELEPHONY_H_)
 #define _SPANDSP_TELEPHONY_H_
 
-#if defined(_M_IX86)  ||  defined(_M_X64)
+#if defined(_M_IX86)  ||  defined(_M_X64)  ||  defined(_M_ARM64)
 #if defined(LIBSPANDSP_EXPORTS)
 #define SPAN_DECLARE(type)              __declspec(dllexport) type
 #define SPAN_DECLARE_DATA               __declspec(dllexport)


### PR DESCRIPTION
This doesn't add complete support for building for Arm64 with Visual C++, but it does let you include a SpanDSP package built with MinGW in a Visual C++ project.