### PR TITLE
install the private/v80.h header file

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -106,7 +106,7 @@ version_compare()
 
 # Check for required version and die if unhappy
 
-mkdir config
+mkdir -p config
 
 if [ "x$UNAME" = "xDarwin" ]; then
 version_compare glibtoolize 1 5 16 || exit 1

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -346,6 +346,7 @@ nobase_include_HEADERS = spandsp/ademco_contactid.h \
                          spandsp/private/v42.h \
                          spandsp/private/v42bis.h \
                          spandsp/private/v8.h \
+                         spandsp/private/v80.h \
                          spandsp/expose.h
 
 nodist_include_HEADERS = spandsp.h


### PR DESCRIPTION
Hi.  I noticed this when attempting to build freeswitch.  It looks like `private/v80.h` needs to be installed along with `expose.h`.  The reference to private/v80.h was added in d8dfbd74.

```
making all mod_spandsp
make[4]: Entering directory '/tmp/sources/freeswitch/src/mod/applications/mod_spandsp'
  CC       mod_spandsp_la-mod_spandsp.lo
In file included from /usr/local/include/spandsp.h:154,
                 from mod_spandsp.h:50,
                 from mod_spandsp.c:39:
/usr/local/include/spandsp/expose.h:69:10: fatal error: spandsp/private/v80.h: No such file or directory
   69 | #include <spandsp/private/v80.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[4]: Leaving directory '/tmp/sources/freeswitch/src/mod/applications/mod_spandsp'
```

This PR also includes a tweak to autogen.h, which carps about the `./config` directory that already exists.  I'm happy to split that into a separate PR, or modify this one to remove the `mkdir` entirely.  I'm not sure under what circumstance the directory wouldn't exist since it is part of the repo.