### PR TITLE
tone_detect.h: fix missing ')' for SPANDSP_USE_FIXED_POINT

### DIFF
--- a/src/spandsp/tone_detect.h
+++ b/src/spandsp/tone_detect.h
@@ -60,8 +60,8 @@ struct goertzel_state_s
 /* Convert a power level in dBm0 or dBov to the equivalent result from a Goertzel filter. This is len*len times the actual power, since
    the DFT calculation accumulates at the square of the number of samples. */
 #if defined(SPANDSP_USE_FIXED_POINT)
-#define goertzel_threshold_dbm0(len,thresh)     (int) ((len*len*256.0*256.0/2.0*pow(10.0, (thresh - DBM0_MAX_SINE_POWER)/10.0))
-#define goertzel_threshold_dbmov(len,thresh)    (int) ((len*len*256.0*256.0/2.0*pow(10.0, (thresh - DBMOV_MAX_SINE_POWER)/10.0))
+#define goertzel_threshold_dbm0(len,thresh)     (int) ((len*len*256.0*256.0/2.0)*pow(10.0, (thresh - DBM0_MAX_SINE_POWER)/10.0))
+#define goertzel_threshold_dbmov(len,thresh)    (int) ((len*len*256.0*256.0/2.0)*pow(10.0, (thresh - DBMOV_MAX_SINE_POWER)/10.0))
 #else
 #define goertzel_threshold_dbm0(len,thresh)     (float) ((len*len*32768.0*32768.0/2.0)*pow(10.0, (thresh - DBM0_MAX_SINE_POWER)/10.0))
 #define goertzel_threshold_dbmov(len,thresh)    (float) ((len*len*32768.0*32768.0/2.0)*pow(10.0, (thresh - DBMOV_MAX_SINE_POWER)/10.0))


### PR DESCRIPTION
* fixes: https://github.com/freeswitch/spandsp/commit/5394b2cae6c482ccb835335b769469977e6802ae#commitcomment-139934289

```
libtool: compile:  ccache arm-oe-linux-gnueabi-gcc -mthumb -mfpu=neon -mfloat-abi=softfp -mcpu=cortex-a9 -mtune=cortex-a9 -fstack-protector-strong -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -funwind-tables -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64 --sysroot=TOPDIR/BUILD/work/mach-oe-linux-gnueabi/lib32-spandsp/3.0.0+git/lib32-recipe-sysroot -DHAVE_CONFIG_H -I. -I../../git/src -I.. -DNDEBUG -Wunused-but-set-variable -std=gnu99 -ffast-math -Wall -Wunused-variable -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -fvisibility=hidden -DHAVE_VISIBILITY=1 -O2 -pipe -g -feliminate-unused-debug-types -fcanon-prefix-map -fmacro-prefix-map=TOPDIR/BUILD/work/mach-oe-linux-gnueabi/lib32-spandsp/3.0.0+git/git=/usr/src/debug/lib32-spandsp/3.0.0+git -fdebug-prefix-map=TOPDIR/BUILD/work/mach-oe-linux-gnueabi/lib32-spandsp/3.0.0+git/git=/usr/src/debug/lib32-spandsp/3.0.0+git -fmacro-prefix-map=TOPDIR/BUILD/work/mach-oe-linux-gnueabi/lib32-spandsp/3.0.0+git/build=/usr/src/debug/lib32-spandsp/3.0.0+git -fdebug-prefix-map=TOPDIR/BUILD/work/mach-oe-linux-gnueabi/lib32-spandsp/3.0.0+git/build=/usr/src/debug/lib32-spandsp/3.0.0+git -fdebug-prefix-map=TOPDIR/BUILD/work/mach-oe-linux-gnueabi/lib32-spandsp/3.0.0+git/lib32-recipe-sysroot= -fmacro-prefix-map=TOPDIR/BUILD/work/mach-oe-linux-gnueabi/lib32-spandsp/3.0.0+git/lib32-recipe-sysroot= -fdebug-prefix-map=TOPDIR/BUILD/work/mach-oe-linux-gnueabi/lib32-spandsp/3.0.0+git/recipe-sysroot-native= -c ../../git/src/t38_terminal.c  -fPIC -DPIC -o .libs/t38_terminal.o ../../git/src/ademco_contactid.c:449:110: error: expected ')' before ';' token
  449 | static const int detection_threshold            = goertzel_threshold_dbm0(GOERTZEL_SAMPLES_PER_BLOCK, -42.0f);
      |                                                                                                              ^
In file included from ../../git/src/ademco_contactid.c:66:
../../git/src/spandsp/tone_detect.h:63:55: note: to match this '('
   63 | #define goertzel_threshold_dbm0(len,thresh)     (int) ((len*len*256.0*256.0/2.0*pow(10.0, (thresh - DBM0_MAX_SINE_POWER)/10.0))
      |                                                       ^
../../git/src/ademco_contactid.c:449:51: note: in expansion of macro 'goertzel_threshold_dbm0'
  449 | static const int detection_threshold            = goertzel_threshold_dbm0(GOERTZEL_SAMPLES_PER_BLOCK, -42.0f);
      |                                                   ^~~~~~~~~~~~~~~~~~~~~~~
../../git/src/ademco_contactid.c:449:18: warning: 'detection_threshold' defined but not used [-Wunused-const-variable=]
  449 | static const int detection_threshold            = goertzel_threshold_dbm0(GOERTZEL_SAMPLES_PER_BLOCK, -42.0f);
      |                  ^~~~~~~~~~~~~~~~~~~
../../git/src/ademco_contactid.c:210:35: warning: 'ademco_codes' defined but not used [-Wunused-const-variable=]
  210 | static const struct ademco_code_s ademco_codes[] =
      |                                   ^~~~~~~~~~~~
make[2]: *** [Makefile:1091: ademco_contactid.lo] Error 1
```