### PR TITLE
[BUILD] Add `docbook-xsl` build-dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: spandsp
 Section: libs
 Priority: optional
 Maintainer: FreeSWITCH Solutions <packages@freeswitch.com>
-Build-Depends: debhelper (>= 9), libtiff-dev, libjpeg-dev, doxygen, autotools-dev, xsltproc
+Build-Depends: debhelper (>= 9), libtiff-dev, libjpeg-dev, doxygen, autotools-dev, docbook-xsl, xsltproc
 Standards-Version: 3.9.6
 
 Package: libspandsp3


### PR DESCRIPTION
Compilation fails if `docbook-xsl` is not installed

```
cd t38_manual ; xsltproc ../wrapper.xsl ../t38_manual.xml
error : Unknown IO error
warning: failed to load external entity "http://docbook.sourceforge.net/release/xsl/current/xhtml/chunk.xsl"
compilation error: file ../wrapper.xsl line 3 element import
xsl:import : unable to load http://docbook.sourceforge.net/release/xsl/current/xhtml/chunk.xsl
make[3]: *** [Makefile:492: t38_manual/index.html] Error 5
```