### PR TITLE
Use "inline" instead of "__inline__"

### DIFF
--- a/spandsp-sim/g1050.c
+++ b/spandsp-sim/g1050.c
@@ -900,32 +900,32 @@ g1050_model_t g1050_standard_models[9] =
 };
 
 #if defined(HAVE_DRAND48)
-static __inline__ void q1050_rand_init(void)
+static inline void q1050_rand_init(void)
 {
     srand48(time(NULL));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ double q1050_rand(void)
+static inline double q1050_rand(void)
 {
     return drand48();
 }
 /*- End of function --------------------------------------------------------*/
 #else
-static __inline__ void q1050_rand_init(void)
+static inline void q1050_rand_init(void)
 {
     srand(time(NULL));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ double q1050_rand(void)
+static inline double q1050_rand(void)
 {
     return (double) rand()/(double) RAND_MAX;
 }
 /*- End of function --------------------------------------------------------*/
 #endif
 
-static __inline__ double scale_probability(double prob, double scale)
+static inline double scale_probability(double prob, double scale)
 {
     /* Re-calculate probability based on a different time interval */
     return 1.0 - pow(1.0 - prob, scale);

--- a/spandsp-sim/test_utils.c
+++ b/spandsp-sim/test_utils.c
@@ -165,7 +165,7 @@ SPAN_DECLARE(complexf_t) complexify(complexify_state_t *s, int16_t amp)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complex_t expj(double theta)
+static inline complex_t expj(double theta)
 {
     return complex_set(cos(theta), sin(theta));
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -686,7 +686,7 @@ $(VCPROJ12): msvc/vc12proj.head msvc/vc12proj.foot Makefile.am
 
 $(srcdir)/msvc/spandsp.h: spandsp.h.in
 	echo "creating $(srcdir)/msvc/spandsp.h"
-	@sed -e "s/#define _SPANDSP_H_/#define _SPANDSP_H_\n\n#define __inline__ __inline\n#pragma warning(disable:4200)/" \
+	@sed -e "s/#define _SPANDSP_H_/#define _SPANDSP_H_\n\n#pragma warning(disable:4200)/" \
 	     -e "s/\@SPANDSP_USE_FIXED_POINT\@/#undef SPANDSP_USE_FIXED_POINT/" \
 	     -e "s/\@SPANDSP_MISALIGNED_ACCESS_FAILS\@/#undef SPANDSP_MISALIGNED_ACCESS_FAILS/" \
 	     -e "s/\@SPANDSP_USE_EXPORT_CAPABILITY\@/#define SPANDSP_USE_EXPORT_CAPABILITY 1/" \

--- a/src/dds_float.c
+++ b/src/dds_float.c
@@ -2130,7 +2130,7 @@ SPAN_DECLARE(float) dds_scaling_dbovf(float level)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ float dds_lookupx(uint32_t phase)
+static inline float dds_lookupx(uint32_t phase)
 {
     return sine_table[phase >> (32 - SLENK)];
 }

--- a/src/echo.c
+++ b/src/echo.c
@@ -174,7 +174,7 @@ static int narrowband_detect(echo_can_state_t *ec)
     return score;
 }
 
-static __inline__ void lms_adapt(echo_can_state_t *ec, int factor)
+static inline void lms_adapt(echo_can_state_t *ec, int factor)
 {
     int i;
 
@@ -379,7 +379,7 @@ SPAN_DECLARE(void) echo_can_snapshot(echo_can_state_t *ec)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t echo_can_hpf(int32_t coeff[2], int16_t amp)
+static inline int16_t echo_can_hpf(int32_t coeff[2], int16_t amp)
 {
     int32_t z;
 

--- a/src/filter_tools.c
+++ b/src/filter_tools.c
@@ -59,13 +59,13 @@
 
 static complex_t circle[MAX_FFT_LEN/2];
 
-static __inline__ complex_t expj(double theta)
+static inline complex_t expj(double theta)
 {
     return complex_set(cos(theta), sin(theta));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ double fix(double x)
+static inline double fix(double x)
 {
     /* Nearest integer */
     return (x >= 0.0)  ?  floor(0.5 + x)  :  -floor(0.5 - x);

--- a/src/floating_fudge.h
+++ b/src/floating_fudge.h
@@ -35,42 +35,42 @@ extern "C"
 #endif
 
 #if !defined(HAVE_SINF)
-static __inline__ float sinf(float x)
+static inline float sinf(float x)
 {
     return (float) sin((double) x);
 }
 #endif
 
 #if !defined(HAVE_COSF)
-static __inline__ float cosf(float x)
+static inline float cosf(float x)
 {
     return (float) cos((double) x);
 }
 #endif
 
 #if !defined(HAVE_TANF)
-static __inline__ float tanf(float x)
+static inline float tanf(float x)
 {
     return (float) tan((double) x);
 }
 #endif
 
 #if !defined(HAVE_ASINF)
-static __inline__ float asinf(float x)
+static inline float asinf(float x)
 {
     return (float) asin((double) x);
 }
 #endif
 
 #if !defined(HAVE_ACOSF)
-static __inline__ float acosf(float x)
+static inline float acosf(float x)
 {
     return (float) acos((double) x);
 }
 #endif
 
 #if !defined(HAVE_ATANF)
-static __inline__ float atanf(float x)
+static inline float atanf(float x)
 {
     return (float) atan((double) x);
 }
@@ -78,7 +78,7 @@ static __inline__ float atanf(float x)
 #endif
 
 #if !defined(HAVE_ATAN2F)
-static __inline__ float atan2f(float y, float x)
+static inline float atan2f(float y, float x)
 {
     return (float) atan2((double) y, (double) x);
 }
@@ -86,14 +86,14 @@ static __inline__ float atan2f(float y, float x)
 #endif
 
 #if !defined(HAVE_CEILF)
-static __inline__ float ceilf(float x)
+static inline float ceilf(float x)
 {
     return (float) ceil((double) x);
 }
 #endif
 
 #if !defined(HAVE_FLOORF)
-static __inline__ float floorf(float x)
+static inline float floorf(float x)
 {
     return (float) floor((double) x);
 }
@@ -101,28 +101,28 @@ static __inline__ float floorf(float x)
 #endif
 
 #if !defined(HAVE_POWF)
-static __inline__ float powf(float x, float y)
+static inline float powf(float x, float y)
 {
     return (float) pow((double) x, (double) y);
 }
 #endif
 
 #if !defined(HAVE_EXPF)
-static __inline__ float expf(float x)
+static inline float expf(float x)
 {
     return (float) expf((double) x);
 }
 #endif
 
 #if !defined(HAVE_LOGF)
-static __inline__ float logf(float x)
+static inline float logf(float x)
 {
     return (float) logf((double) x);
 }
 #endif
 
 #if !defined(HAVE_LOG10F)
-static __inline__ float log10f(float x)
+static inline float log10f(float x)
 {
     return (float) log10((double) x);
 }

--- a/src/g726.c
+++ b/src/g726.c
@@ -242,7 +242,7 @@ static int16_t fmult(int16_t an, int16_t srn)
 /*
  * Compute the estimated signal from the 6-zero predictor.
  */
-static __inline__ int16_t predictor_zero(g726_state_t *s)
+static inline int16_t predictor_zero(g726_state_t *s)
 {
     int i;
     int sezi;
@@ -259,7 +259,7 @@ static __inline__ int16_t predictor_zero(g726_state_t *s)
 /*
  * Computes the estimated signal from the 2-pole predictor.
  */
-static __inline__ int16_t predictor_pole(g726_state_t *s)
+static inline int16_t predictor_pole(g726_state_t *s)
 {
     return (fmult(s->a[1] >> 2, s->sr[1]) + fmult(s->a[0] >> 2, s->sr[0]));
 }

--- a/src/gsm0610_local.h
+++ b/src/gsm0610_local.h
@@ -35,7 +35,7 @@
 
 #include "spandsp/private/gsm0610.h"
 
-static __inline__ int16_t gsm_add(int16_t a, int16_t b)
+static inline int16_t gsm_add(int16_t a, int16_t b)
 {
 #if defined(__GNUC__)  &&  (defined(__i386__)  ||  defined(__x86_64__))
     __asm__ __volatile__(
@@ -58,7 +58,7 @@ static __inline__ int16_t gsm_add(int16_t a, int16_t b)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int32_t gsm_l_add(int32_t a, int32_t b)
+static inline int32_t gsm_l_add(int32_t a, int32_t b)
 {
 #if defined(__GNUC__)  &&  (defined(__i386__)  ||  defined(__x86_64__))
     __asm__ __volatile__(
@@ -93,7 +93,7 @@ static __inline__ int32_t gsm_l_add(int32_t a, int32_t b)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t gsm_sub(int16_t a, int16_t b)
+static inline int16_t gsm_sub(int16_t a, int16_t b)
 {
     int32_t diff;
 
@@ -102,7 +102,7 @@ static __inline__ int16_t gsm_sub(int16_t a, int16_t b)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t gsm_mult(int16_t a, int16_t b)
+static inline int16_t gsm_mult(int16_t a, int16_t b)
 {
     if (a == INT16_MIN  &&  b == INT16_MIN)
         return INT16_MAX;
@@ -111,14 +111,14 @@ static __inline__ int16_t gsm_mult(int16_t a, int16_t b)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int32_t gsm_l_mult(int16_t a, int16_t b)
+static inline int32_t gsm_l_mult(int16_t a, int16_t b)
 {
     assert (a != INT16_MIN  ||  b != INT16_MIN);
     return ((int32_t) a * (int32_t) b) << 1;
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t gsm_mult_r(int16_t a, int16_t b)
+static inline int16_t gsm_mult_r(int16_t a, int16_t b)
 {
     int32_t prod;
 
@@ -131,13 +131,13 @@ static __inline__ int16_t gsm_mult_r(int16_t a, int16_t b)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t gsm_abs(int16_t a)
+static inline int16_t gsm_abs(int16_t a)
 {
     return (a == INT16_MIN)  ?  INT16_MAX  :  (int16_t) abs(a);
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t gsm_asr(int16_t a, int n)
+static inline int16_t gsm_asr(int16_t a, int n)
 {
     if (n >= 16)
         return (int16_t) (-(a < 0));
@@ -152,7 +152,7 @@ static __inline__ int16_t gsm_asr(int16_t a, int n)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t gsm_asl(int16_t a, int n)
+static inline int16_t gsm_asl(int16_t a, int n)
 {
     if (n >= 16)
         return 0;

--- a/src/hdlc.c
+++ b/src/hdlc.c
@@ -85,7 +85,7 @@ static void rx_special_condition(hdlc_rx_state_t *s, int status)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void octet_set_and_count(hdlc_rx_state_t *s)
+static inline void octet_set_and_count(hdlc_rx_state_t *s)
 {
     if (s->octet_count_report_interval == 0)
         return;
@@ -111,7 +111,7 @@ static __inline__ void octet_set_and_count(hdlc_rx_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void octet_count(hdlc_rx_state_t *s)
+static inline void octet_count(hdlc_rx_state_t *s)
 {
     if (s->octet_count_report_interval == 0)
         return;
@@ -245,7 +245,7 @@ static void rx_flag_or_abort(hdlc_rx_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void hdlc_rx_put_bit_core(hdlc_rx_state_t *s)
+static inline void hdlc_rx_put_bit_core(hdlc_rx_state_t *s)
 {
     if ((s->raw_bit_stream & 0x3E00) == 0x3E00)
     {

--- a/src/image_translate.c
+++ b/src/image_translate.c
@@ -519,7 +519,7 @@ static int image_resize_row(image_translate_state_t *s, uint8_t buf[])
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint8_t find_closest_palette_color(int in)
+static inline uint8_t find_closest_palette_color(int in)
 {
     return (in >= 128)  ?  255  :  0;
 }

--- a/src/lpc10_analyse.c
+++ b/src/lpc10_analyse.c
@@ -54,7 +54,7 @@
 
 #include "lpc10_encdecs.h"
 
-static __inline__ float energyf(float amp[], int len)
+static inline float energyf(float amp[], int len)
 {
     int i;
     float rms;

--- a/src/lpc10_encdecs.h
+++ b/src/lpc10_encdecs.h
@@ -68,7 +68,7 @@ void lpc10_voicing(lpc10_encode_state_t *st,
 
 void lpc10_analyse(lpc10_encode_state_t *st, float *speech, int32_t *voice, int32_t *pitch, float *rms, float rc[]);
 
-static __inline__ int32_t pow_ii(int32_t x, int32_t n)
+static inline int32_t pow_ii(int32_t x, int32_t n)
 {
     int32_t pow;
     uint32_t u;
@@ -94,7 +94,7 @@ static __inline__ int32_t pow_ii(int32_t x, int32_t n)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ float r_sign(float a, float b)
+static inline float r_sign(float a, float b)
 {
     float x;
 

--- a/src/make_modem_filter.c
+++ b/src/make_modem_filter.c
@@ -37,10 +37,6 @@
 #include <getopt.h>
 #endif
 
-#if defined (_MSC_VER)
- #define __inline__ __inline
-#endif
-
 #include "spandsp/telephony.h"
 #include "spandsp/complex.h"
 #include "filter_tools.h"

--- a/src/msvc/config.h
+++ b/src/msvc/config.h
@@ -71,8 +71,6 @@
   #if _MSC_VER < 1900
   #define snprintf _snprintf
   #endif
-  #define inline __inline
-  #define __inline__ __inline
 
   #define _MMX_H_
 

--- a/src/msvc/spandsp.h
+++ b/src/msvc/spandsp.h
@@ -28,7 +28,6 @@
 #if !defined(_SPANDSP_H_)
 #define _SPANDSP_H_
 
-#define __inline__ __inline
 #pragma warning(disable:4200)
 
 #undef SPANDSP_USE_FIXED_POINT

--- a/src/plc.c
+++ b/src/plc.c
@@ -80,7 +80,7 @@ static void save_history(plc_state_t *s, int16_t *buf, int len)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void normalise_history(plc_state_t *s)
+static inline void normalise_history(plc_state_t *s)
 {
     int16_t tmp[PLC_HISTORY_LEN];
 
@@ -94,7 +94,7 @@ static __inline__ void normalise_history(plc_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int amdf_pitch(int min_pitch, int max_pitch, int16_t amp[], int len)
+static inline int amdf_pitch(int min_pitch, int max_pitch, int16_t amp[], int len)
 {
     int i;
     int j;

--- a/src/spandsp/arctan2.h
+++ b/src/spandsp/arctan2.h
@@ -44,7 +44,7 @@ extern "C"
 #endif
 
 /* This returns its answer as a signed 32 bit integer phase value. */
-static __inline__ int32_t arctan2(float y, float x)
+static inline int32_t arctan2(float y, float x)
 {
     float abs_y;
     float angle;
@@ -81,7 +81,7 @@ static __inline__ int32_t arctan2(float y, float x)
 
 #if 0
 /* This returns its answer in radians, in the range +-pi. */
-static __inline__ float arctan2f(float y, float x)
+static inline float arctan2f(float y, float x)
 {
     float angle;
     float fx;

--- a/src/spandsp/biquad.h
+++ b/src/spandsp/biquad.h
@@ -59,7 +59,7 @@ extern "C"
 {
 #endif
 
-static __inline__ void biquad2_init(biquad2_state_t *bq,
+static inline void biquad2_init(biquad2_state_t *bq,
                                     int32_t gain,
                                     int32_t a1,
                                     int32_t a2,
@@ -84,7 +84,7 @@ static __inline__ void biquad2_init(biquad2_state_t *bq,
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t biquad2(biquad2_state_t *bq, int16_t sample)
+static inline int16_t biquad2(biquad2_state_t *bq, int16_t sample)
 {
     int32_t y;
     int32_t z0;

--- a/src/spandsp/bit_operations.h
+++ b/src/spandsp/bit_operations.h
@@ -42,7 +42,7 @@ extern "C"
 /*! \brief Find the bit position of the highest set bit in a word
     \param bits The word to be searched
     \return The bit number of the highest set bit, or -1 if the word is zero. */
-static __inline__ int top_bit(uint32_t bits)
+static inline int top_bit(uint32_t bits)
 {
 #if defined(SPANDSP_USE_86_ASM)
     int res;
@@ -148,7 +148,7 @@ static __inline__ int top_bit(uint32_t bits)
 /*! \brief Find the bit position of the lowest set bit in a word
     \param bits The word to be searched
     \return The bit number of the lowest set bit, or -1 if the word is zero. */
-static __inline__ int bottom_bit(uint32_t bits)
+static inline int bottom_bit(uint32_t bits)
 {
     int res;
 
@@ -196,7 +196,7 @@ static __inline__ int bottom_bit(uint32_t bits)
 /*! \brief Bit reverse a byte.
     \param data The byte to be reversed.
     \return The bit reversed version of data. */
-static __inline__ uint8_t bit_reverse8(uint8_t x)
+static inline uint8_t bit_reverse8(uint8_t x)
 {
 #if defined(__i386__)  ||  defined(__x86_64__)  ||  defined(__ppc__)  ||  defined(__powerpc__)
     /* If multiply is fast */
@@ -257,7 +257,7 @@ SPAN_DECLARE(uint16_t) make_mask16(uint16_t x);
            with just that bit set.
     \param x The word to be searched.
     \return The word with the single set bit. */
-static __inline__ uint32_t least_significant_one32(uint32_t x)
+static inline uint32_t least_significant_one32(uint32_t x)
 {
     return (x & (-(int32_t) x));
 }
@@ -267,7 +267,7 @@ static __inline__ uint32_t least_significant_one32(uint32_t x)
            with just that bit set.
     \param x The word to be searched.
     \return The word with the single set bit. */
-static __inline__ uint32_t most_significant_one32(uint32_t x)
+static inline uint32_t most_significant_one32(uint32_t x)
 {
 #if defined(__i386__)  ||  defined(__x86_64__)  ||  defined(__ppc__)  ||  defined(__powerpc__)
     return 1 << top_bit(x);
@@ -281,7 +281,7 @@ static __inline__ uint32_t most_significant_one32(uint32_t x)
 /*! \brief Find the parity of a byte.
     \param x The byte to be checked.
     \return 1 for odd, or 0 for even. */
-static __inline__ int parity8(uint8_t x)
+static inline int parity8(uint8_t x)
 {
     x = (x ^ (x >> 4)) & 0x0F;
     return (0x6996 >> x) & 1;
@@ -291,7 +291,7 @@ static __inline__ int parity8(uint8_t x)
 /*! \brief Find the parity of a 16 bit word.
     \param x The word to be checked.
     \return 1 for odd, or 0 for even. */
-static __inline__ int parity16(uint16_t x)
+static inline int parity16(uint16_t x)
 {
     x ^= (x >> 8);
     x = (x ^ (x >> 4)) & 0x0F;
@@ -302,7 +302,7 @@ static __inline__ int parity16(uint16_t x)
 /*! \brief Find the parity of a 32 bit word.
     \param x The word to be checked.
     \return 1 for odd, or 0 for even. */
-static __inline__ int parity32(uint32_t x)
+static inline int parity32(uint32_t x)
 {
     x ^= (x >> 16);
     x ^= (x >> 8);

--- a/src/spandsp/complex.h
+++ b/src/spandsp/complex.h
@@ -109,7 +109,7 @@ extern "C"
 {
 #endif
 
-static __inline__ complexf_t complex_setf(float re, float im)
+static inline complexf_t complex_setf(float re, float im)
 {
     complexf_t z;
 
@@ -119,7 +119,7 @@ static __inline__ complexf_t complex_setf(float re, float im)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complex_t complex_set(double re, double im)
+static inline complex_t complex_set(double re, double im)
 {
     complex_t z;
 
@@ -130,7 +130,7 @@ static __inline__ complex_t complex_set(double re, double im)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(HAVE_LONG_DOUBLE)
-static __inline__ complexl_t complex_setl(long double re, long double im)
+static inline complexl_t complex_setl(long double re, long double im)
 {
     complexl_t z;
 
@@ -141,7 +141,7 @@ static __inline__ complexl_t complex_setl(long double re, long double im)
 /*- End of function --------------------------------------------------------*/
 #endif
 
-static __inline__ complexi_t complex_seti(int re, int im)
+static inline complexi_t complex_seti(int re, int im)
 {
     complexi_t z;
 
@@ -151,7 +151,7 @@ static __inline__ complexi_t complex_seti(int re, int im)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexi16_t complex_seti16(int16_t re, int16_t im)
+static inline complexi16_t complex_seti16(int16_t re, int16_t im)
 {
     complexi16_t z;
 
@@ -161,7 +161,7 @@ static __inline__ complexi16_t complex_seti16(int16_t re, int16_t im)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexi32_t complex_seti32(int32_t re, int32_t im)
+static inline complexi32_t complex_seti32(int32_t re, int32_t im)
 {
     complexi32_t z;
 
@@ -171,7 +171,7 @@ static __inline__ complexi32_t complex_seti32(int32_t re, int32_t im)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexf_t complex_addf(const complexf_t *x, const complexf_t *y)
+static inline complexf_t complex_addf(const complexf_t *x, const complexf_t *y)
 {
     complexf_t z;
 
@@ -181,7 +181,7 @@ static __inline__ complexf_t complex_addf(const complexf_t *x, const complexf_t 
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complex_t complex_add(const complex_t *x, const complex_t *y)
+static inline complex_t complex_add(const complex_t *x, const complex_t *y)
 {
     complex_t z;
 
@@ -192,7 +192,7 @@ static __inline__ complex_t complex_add(const complex_t *x, const complex_t *y)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(HAVE_LONG_DOUBLE)
-static __inline__ complexl_t complex_addl(const complexl_t *x, const complexl_t *y)
+static inline complexl_t complex_addl(const complexl_t *x, const complexl_t *y)
 {
     complexl_t z;
 
@@ -203,7 +203,7 @@ static __inline__ complexl_t complex_addl(const complexl_t *x, const complexl_t 
 /*- End of function --------------------------------------------------------*/
 #endif
 
-static __inline__ complexi_t complex_addi(const complexi_t *x, const complexi_t *y)
+static inline complexi_t complex_addi(const complexi_t *x, const complexi_t *y)
 {
     complexi_t z;
 
@@ -213,7 +213,7 @@ static __inline__ complexi_t complex_addi(const complexi_t *x, const complexi_t 
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexi16_t complex_addi16(const complexi16_t *x, const complexi16_t *y)
+static inline complexi16_t complex_addi16(const complexi16_t *x, const complexi16_t *y)
 {
     complexi16_t z;
 
@@ -223,7 +223,7 @@ static __inline__ complexi16_t complex_addi16(const complexi16_t *x, const compl
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexi32_t complex_addi32(const complexi32_t *x, const complexi32_t *y)
+static inline complexi32_t complex_addi32(const complexi32_t *x, const complexi32_t *y)
 {
     complexi32_t z;
 
@@ -233,7 +233,7 @@ static __inline__ complexi32_t complex_addi32(const complexi32_t *x, const compl
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexf_t complex_subf(const complexf_t *x, const complexf_t *y)
+static inline complexf_t complex_subf(const complexf_t *x, const complexf_t *y)
 {
     complexf_t z;
 
@@ -243,7 +243,7 @@ static __inline__ complexf_t complex_subf(const complexf_t *x, const complexf_t 
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complex_t complex_sub(const complex_t *x, const complex_t *y)
+static inline complex_t complex_sub(const complex_t *x, const complex_t *y)
 {
     complex_t z;
 
@@ -254,7 +254,7 @@ static __inline__ complex_t complex_sub(const complex_t *x, const complex_t *y)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(HAVE_LONG_DOUBLE)
-static __inline__ complexl_t complex_subl(const complexl_t *x, const complexl_t *y)
+static inline complexl_t complex_subl(const complexl_t *x, const complexl_t *y)
 {
     complexl_t z;
 
@@ -265,7 +265,7 @@ static __inline__ complexl_t complex_subl(const complexl_t *x, const complexl_t 
 /*- End of function --------------------------------------------------------*/
 #endif
 
-static __inline__ complexi_t complex_subi(const complexi_t *x, const complexi_t *y)
+static inline complexi_t complex_subi(const complexi_t *x, const complexi_t *y)
 {
     complexi_t z;
 
@@ -275,7 +275,7 @@ static __inline__ complexi_t complex_subi(const complexi_t *x, const complexi_t 
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexi16_t complex_subi16(const complexi16_t *x, const complexi16_t *y)
+static inline complexi16_t complex_subi16(const complexi16_t *x, const complexi16_t *y)
 {
     complexi16_t z;
 
@@ -285,7 +285,7 @@ static __inline__ complexi16_t complex_subi16(const complexi16_t *x, const compl
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexi32_t complex_subi32(const complexi32_t *x, const complexi32_t *y)
+static inline complexi32_t complex_subi32(const complexi32_t *x, const complexi32_t *y)
 {
     complexi32_t z;
 
@@ -295,7 +295,7 @@ static __inline__ complexi32_t complex_subi32(const complexi32_t *x, const compl
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexf_t complex_mulf(const complexf_t *x, const complexf_t *y)
+static inline complexf_t complex_mulf(const complexf_t *x, const complexf_t *y)
 {
     complexf_t z;
 
@@ -305,7 +305,7 @@ static __inline__ complexf_t complex_mulf(const complexf_t *x, const complexf_t 
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complex_t complex_mul(const complex_t *x, const complex_t *y)
+static inline complex_t complex_mul(const complex_t *x, const complex_t *y)
 {
     complex_t z;
 
@@ -316,7 +316,7 @@ static __inline__ complex_t complex_mul(const complex_t *x, const complex_t *y)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(HAVE_LONG_DOUBLE)
-static __inline__ complexl_t complex_mull(const complexl_t *x, const complexl_t *y)
+static inline complexl_t complex_mull(const complexl_t *x, const complexl_t *y)
 {
     complexl_t z;
 
@@ -327,7 +327,7 @@ static __inline__ complexl_t complex_mull(const complexl_t *x, const complexl_t 
 /*- End of function --------------------------------------------------------*/
 #endif
 
-static __inline__ complexi_t complex_muli(const complexi_t *x, const complexi_t *y)
+static inline complexi_t complex_muli(const complexi_t *x, const complexi_t *y)
 {
     complexi_t z;
 
@@ -337,7 +337,7 @@ static __inline__ complexi_t complex_muli(const complexi_t *x, const complexi_t 
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexi16_t complex_muli16(const complexi16_t *x, const complexi16_t *y)
+static inline complexi16_t complex_muli16(const complexi16_t *x, const complexi16_t *y)
 {
     complexi16_t z;
 
@@ -347,7 +347,7 @@ static __inline__ complexi16_t complex_muli16(const complexi16_t *x, const compl
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexi16_t complex_mul_q1_15(const complexi16_t *x, const complexi16_t *y)
+static inline complexi16_t complex_mul_q1_15(const complexi16_t *x, const complexi16_t *y)
 {
     complexi16_t z;
 
@@ -357,7 +357,7 @@ static __inline__ complexi16_t complex_mul_q1_15(const complexi16_t *x, const co
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexi32_t complex_muli32i16(const complexi32_t *x, const complexi16_t *y)
+static inline complexi32_t complex_muli32i16(const complexi32_t *x, const complexi16_t *y)
 {
     complexi32_t z;
 
@@ -367,7 +367,7 @@ static __inline__ complexi32_t complex_muli32i16(const complexi32_t *x, const co
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexi32_t complex_muli32(const complexi32_t *x, const complexi32_t *y)
+static inline complexi32_t complex_muli32(const complexi32_t *x, const complexi32_t *y)
 {
     complexi32_t z;
 
@@ -377,7 +377,7 @@ static __inline__ complexi32_t complex_muli32(const complexi32_t *x, const compl
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexf_t complex_divf(const complexf_t *x, const complexf_t *y)
+static inline complexf_t complex_divf(const complexf_t *x, const complexf_t *y)
 {
     complexf_t z;
     float f;
@@ -389,7 +389,7 @@ static __inline__ complexf_t complex_divf(const complexf_t *x, const complexf_t 
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complex_t complex_div(const complex_t *x, const complex_t *y)
+static inline complex_t complex_div(const complex_t *x, const complex_t *y)
 {
     complex_t z;
     double f;
@@ -402,7 +402,7 @@ static __inline__ complex_t complex_div(const complex_t *x, const complex_t *y)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(HAVE_LONG_DOUBLE)
-static __inline__ complexl_t complex_divl(const complexl_t *x, const complexl_t *y)
+static inline complexl_t complex_divl(const complexl_t *x, const complexl_t *y)
 {
     complexl_t z;
     long double f;
@@ -415,7 +415,7 @@ static __inline__ complexl_t complex_divl(const complexl_t *x, const complexl_t 
 /*- End of function --------------------------------------------------------*/
 #endif
 
-static __inline__ complexf_t complex_conjf(const complexf_t *x)
+static inline complexf_t complex_conjf(const complexf_t *x)
 {
     complexf_t z;
 
@@ -425,7 +425,7 @@ static __inline__ complexf_t complex_conjf(const complexf_t *x)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complex_t complex_conj(const complex_t *x)
+static inline complex_t complex_conj(const complex_t *x)
 {
     complex_t z;
 
@@ -436,7 +436,7 @@ static __inline__ complex_t complex_conj(const complex_t *x)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(HAVE_LONG_DOUBLE)
-static __inline__ complexl_t complex_conjl(const complexl_t *x)
+static inline complexl_t complex_conjl(const complexl_t *x)
 {
     complexl_t z;
 
@@ -447,7 +447,7 @@ static __inline__ complexl_t complex_conjl(const complexl_t *x)
 /*- End of function --------------------------------------------------------*/
 #endif
 
-static __inline__ complexi_t complex_conji(const complexi_t *x)
+static inline complexi_t complex_conji(const complexi_t *x)
 {
     complexi_t z;
 
@@ -457,7 +457,7 @@ static __inline__ complexi_t complex_conji(const complexi_t *x)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexi16_t complex_conji16(const complexi16_t *x)
+static inline complexi16_t complex_conji16(const complexi16_t *x)
 {
     complexi16_t z;
 
@@ -467,7 +467,7 @@ static __inline__ complexi16_t complex_conji16(const complexi16_t *x)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexi32_t complex_conji32(const complexi32_t *x)
+static inline complexi32_t complex_conji32(const complexi32_t *x)
 {
     complexi32_t z;
 
@@ -477,26 +477,26 @@ static __inline__ complexi32_t complex_conji32(const complexi32_t *x)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int32_t poweri16(const complexi16_t *x)
+static inline int32_t poweri16(const complexi16_t *x)
 {
     return (int32_t) x->re*x->re + (int32_t) x->im*x->im;
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ float powerf(const complexf_t *x)
+static inline float powerf(const complexf_t *x)
 {
     return x->re*x->re + x->im*x->im;
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ double power(const complex_t *x)
+static inline double power(const complex_t *x)
 {
     return x->re*x->re + x->im*x->im;
 }
 /*- End of function --------------------------------------------------------*/
 
 #if defined(HAVE_LONG_DOUBLE)
-static __inline__ long double powerl(const complexl_t *x)
+static inline long double powerl(const complexl_t *x)
 {
     return x->re*x->re + x->im*x->im;
 }

--- a/src/spandsp/complex_vector_float.h
+++ b/src/spandsp/complex_vector_float.h
@@ -31,7 +31,7 @@ extern "C"
 {
 #endif
 
-static __inline__ void cvec_copyf(complexf_t z[], const complexf_t x[], int n)
+static inline void cvec_copyf(complexf_t z[], const complexf_t x[], int n)
 {
     int i;
 
@@ -40,7 +40,7 @@ static __inline__ void cvec_copyf(complexf_t z[], const complexf_t x[], int n)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void cvec_copy(complex_t z[], const complex_t x[], int n)
+static inline void cvec_copy(complex_t z[], const complex_t x[], int n)
 {
     int i;
 
@@ -50,7 +50,7 @@ static __inline__ void cvec_copy(complex_t z[], const complex_t x[], int n)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(HAVE_LONG_DOUBLE)
-static __inline__ void cvec_copyl(complexl_t z[], const complexl_t x[], int n)
+static inline void cvec_copyl(complexl_t z[], const complexl_t x[], int n)
 {
     int i;
 
@@ -60,7 +60,7 @@ static __inline__ void cvec_copyl(complexl_t z[], const complexl_t x[], int n)
 /*- End of function --------------------------------------------------------*/
 #endif
 
-static __inline__ void cvec_zerof(complexf_t z[], int n)
+static inline void cvec_zerof(complexf_t z[], int n)
 {
     int i;
 
@@ -69,7 +69,7 @@ static __inline__ void cvec_zerof(complexf_t z[], int n)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void cvec_zero(complex_t z[], int n)
+static inline void cvec_zero(complex_t z[], int n)
 {
     int i;
 
@@ -79,7 +79,7 @@ static __inline__ void cvec_zero(complex_t z[], int n)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(HAVE_LONG_DOUBLE)
-static __inline__ void cvec_zerol(complexl_t z[], int n)
+static inline void cvec_zerol(complexl_t z[], int n)
 {
     int i;
 
@@ -89,7 +89,7 @@ static __inline__ void cvec_zerol(complexl_t z[], int n)
 /*- End of function --------------------------------------------------------*/
 #endif
 
-static __inline__ void cvec_setf(complexf_t z[], complexf_t *x, int n)
+static inline void cvec_setf(complexf_t z[], complexf_t *x, int n)
 {
     int i;
 
@@ -98,7 +98,7 @@ static __inline__ void cvec_setf(complexf_t z[], complexf_t *x, int n)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void cvec_set(complex_t z[], complex_t *x, int n)
+static inline void cvec_set(complex_t z[], complex_t *x, int n)
 {
     int i;
 
@@ -108,7 +108,7 @@ static __inline__ void cvec_set(complex_t z[], complex_t *x, int n)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(HAVE_LONG_DOUBLE)
-static __inline__ void cvec_setl(complexl_t z[], complexl_t *x, int n)
+static inline void cvec_setl(complexl_t z[], complexl_t *x, int n)
 {
     int i;
 

--- a/src/spandsp/complex_vector_int.h
+++ b/src/spandsp/complex_vector_int.h
@@ -31,43 +31,43 @@ extern "C"
 {
 #endif
 
-static __inline__ void cvec_copyi(complexi_t z[], const complexi_t x[], int n)
+static inline void cvec_copyi(complexi_t z[], const complexi_t x[], int n)
 {
     memcpy(z, x, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void cvec_copyi16(complexi16_t z[], const complexi16_t x[], int n)
+static inline void cvec_copyi16(complexi16_t z[], const complexi16_t x[], int n)
 {
     memcpy(z, x, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void cvec_copyi32(complexi32_t z[], const complexi32_t x[], int n)
+static inline void cvec_copyi32(complexi32_t z[], const complexi32_t x[], int n)
 {
     memcpy(z, x, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void cvec_zeroi(complexi_t z[], int n)
+static inline void cvec_zeroi(complexi_t z[], int n)
 {
     memset(z, 0, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void cvec_zeroi16(complexi16_t z[], int n)
+static inline void cvec_zeroi16(complexi16_t z[], int n)
 {
     memset(z, 0, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void cvec_zeroi32(complexi32_t z[], int n)
+static inline void cvec_zeroi32(complexi32_t z[], int n)
 {
     memset(z, 0, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void cvec_seti(complexi_t z[], complexi_t *x, int n)
+static inline void cvec_seti(complexi_t z[], complexi_t *x, int n)
 {
     int i;
 
@@ -76,7 +76,7 @@ static __inline__ void cvec_seti(complexi_t z[], complexi_t *x, int n)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void cvec_seti16(complexi16_t z[], complexi16_t *x, int n)
+static inline void cvec_seti16(complexi16_t z[], complexi16_t *x, int n)
 {
     int i;
 
@@ -85,7 +85,7 @@ static __inline__ void cvec_seti16(complexi16_t z[], complexi16_t *x, int n)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void cvec_seti32(complexi32_t z[], complexi32_t *x, int n)
+static inline void cvec_seti32(complexi32_t z[], complexi32_t *x, int n)
 {
     int i;
 

--- a/src/spandsp/dc_restore.h
+++ b/src/spandsp/dc_restore.h
@@ -64,20 +64,20 @@ extern "C"
 {
 #endif
 
-static __inline__ void dc_restore_init(dc_restore_state_t *dc)
+static inline void dc_restore_init(dc_restore_state_t *dc)
 {
     dc->state = 0;
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t dc_restore(dc_restore_state_t *dc, int16_t sample)
+static inline int16_t dc_restore(dc_restore_state_t *dc, int16_t sample)
 {
     dc->state += ((((int32_t) sample << 15) - dc->state) >> 14);
     return (int16_t) (sample - (dc->state >> 15));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t dc_restore_estimate(dc_restore_state_t *dc)
+static inline int16_t dc_restore_estimate(dc_restore_state_t *dc)
 {
     return (int16_t) (dc->state >> 15);
 }

--- a/src/spandsp/fast_convert.h
+++ b/src/spandsp/fast_convert.h
@@ -89,7 +89,7 @@ extern "C"
      *    These replacement functions (pulled from the Public Domain MinGW
      *    math.h header) replace the native versions.
      */
-    static __inline__ long int lrint(double x)
+    static inline long int lrint(double x)
     {
         long int retval;
 
@@ -104,7 +104,7 @@ extern "C"
         return retval;
     }
 
-    static __inline__ long int lrintf(float x)
+    static inline long int lrintf(float x)
     {
         long int retval;
 
@@ -120,7 +120,7 @@ extern "C"
 #endif
 
     /* The fastest way to convert is the equivalent of lrint() */
-    static __inline__ long int lfastrint(double x)
+    static inline long int lfastrint(double x)
     {
         long int retval;
 
@@ -135,7 +135,7 @@ extern "C"
         return retval;
     }
 
-    static __inline__ long int lfastrintf(float x)
+    static inline long int lfastrintf(float x)
     {
         long int retval;
 
@@ -154,7 +154,7 @@ extern "C"
     /* These routines are guaranteed fast on an i386 machine. Using the built in
        lrint() and lrintf() should be similar, but they may not always be enabled.
        Sometimes, especially with "-O0", you might get slow calls to routines. */
-    static __inline__ long int lfastrint(double x)
+    static inline long int lfastrint(double x)
     {
         long int retval;
 
@@ -169,7 +169,7 @@ extern "C"
         return retval;
     }
 
-    static __inline__ long int lfastrintf(float x)
+    static inline long int lfastrintf(float x)
     {
         long int retval;
 
@@ -186,17 +186,17 @@ extern "C"
     /* On an x86_64 machine, the fastest thing seems to be a pure assignment from a
        double or float to an int. It looks like the design on the x86_64 took account
        of the default behaviour specified for C. */
-    static __inline__ long int lfastrint(double x)
+    static inline long int lfastrint(double x)
     {
         return (long int) (x);
     }
 
-    static __inline__ long int lfastrintf(float x)
+    static inline long int lfastrintf(float x)
     {
         return (long int) (x);
     }
 #elif (defined(__ppc__)  ||  defined(__powerpc__))  &&  !defined(__NO_FPRS__)
-    static __inline__ long int lfastrint(register double x)
+    static inline long int lfastrint(register double x)
     {
         int res[2];
 
@@ -212,7 +212,7 @@ extern "C"
         return res[1];
     }
 
-    static __inline__ long int lfastrintf(register float x)
+    static inline long int lfastrintf(register float x)
     {
         int res[2];
 
@@ -229,12 +229,12 @@ extern "C"
     }
 #else
     /* Fallback routines, for unrecognised platforms */
-    static __inline__ long int lfastrint(double x)
+    static inline long int lfastrint(double x)
     {
         return (long int) x;
     }
 
-    static __inline__ long int lfastrintf(float x)
+    static inline long int lfastrintf(float x)
     {
         return (long int) x;
     }
@@ -343,7 +343,7 @@ extern "C"
 #elif defined(__MWERKS__)  &&  defined(macintosh)
     /* This MacOS 9 solution was provided by Stephane Letz */
 
-    long int __inline__ lfastrint(register double x)
+    long int inline lfastrint(register double x)
     {
         long int res[2];
 
@@ -355,7 +355,7 @@ extern "C"
         return res[1];
     }
 
-    long int __inline__ lfastrintf(register float x)
+    long int inline lfastrintf(register float x)
     {
         long int res[2];
 
@@ -369,7 +369,7 @@ extern "C"
 #elif defined(__MACH__)  &&  defined(__APPLE__)  &&  (defined(__ppc__)  ||  defined(__powerpc__))
     /* For Apple Mac OS/X - do recent versions still need this? */
 
-    static __inline__ long int lfastrint(register double x)
+    static inline long int lfastrint(register double x)
     {
         int res[2];
 
@@ -385,7 +385,7 @@ extern "C"
         return res[1];
     }
 
-    static __inline__ long int lfastrintf(register float x)
+    static inline long int lfastrintf(register float x)
     {
         int res[2];
 
@@ -411,22 +411,22 @@ extern "C"
         #warning "Replacing these functions with a simple C cast."
     #endif
 
-    static __inline__ long int lrint(double x)
+    static inline long int lrint(double x)
     {
         return (long int) (x);
     }
 
-    static __inline__ long int lrintf(float x)
+    static inline long int lrintf(float x)
     {
         return (long int) (x);
     }
 
-    static __inline__ long int lfastrint(double x)
+    static inline long int lfastrint(double x)
     {
         return (long int) (x);
     }
 
-    static __inline__ long int lfastrintf(float x)
+    static inline long int lfastrintf(float x)
     {
         return (long int) (x);
     }

--- a/src/spandsp/fir.h
+++ b/src/spandsp/fir.h
@@ -80,7 +80,7 @@ extern "C"
 {
 #endif
 
-static __inline__ const int16_t *fir16_create(fir16_state_t *fir,
+static inline const int16_t *fir16_create(fir16_state_t *fir,
                                               const int16_t *coeffs,
                                               int taps)
 {
@@ -98,7 +98,7 @@ static __inline__ const int16_t *fir16_create(fir16_state_t *fir,
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void fir16_flush(fir16_state_t *fir)
+static inline void fir16_flush(fir16_state_t *fir)
 {
 #if defined(USE_MMX)  ||  defined(USE_SSE2)
     memset(fir->history, 0, 2*fir->taps*sizeof(int16_t));
@@ -108,13 +108,13 @@ static __inline__ void fir16_flush(fir16_state_t *fir)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void fir16_free(fir16_state_t *fir)
+static inline void fir16_free(fir16_state_t *fir)
 {
     span_free(fir->history);
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t fir16(fir16_state_t *fir, int16_t sample)
+static inline int16_t fir16(fir16_state_t *fir, int16_t sample)
 {
     int i;
     int32_t y;
@@ -203,7 +203,7 @@ static __inline__ int16_t fir16(fir16_state_t *fir, int16_t sample)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ const int16_t *fir32_create(fir32_state_t *fir,
+static inline const int16_t *fir32_create(fir32_state_t *fir,
                                               const int32_t *coeffs,
                                               int taps)
 {
@@ -217,19 +217,19 @@ static __inline__ const int16_t *fir32_create(fir32_state_t *fir,
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void fir32_flush(fir32_state_t *fir)
+static inline void fir32_flush(fir32_state_t *fir)
 {
     memset(fir->history, 0, fir->taps*sizeof(int16_t));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void fir32_free(fir32_state_t *fir)
+static inline void fir32_free(fir32_state_t *fir)
 {
     span_free(fir->history);
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t fir32(fir32_state_t *fir, int16_t sample)
+static inline int16_t fir32(fir32_state_t *fir, int16_t sample)
 {
     int i;
     int32_t y;
@@ -251,7 +251,7 @@ static __inline__ int16_t fir32(fir32_state_t *fir, int16_t sample)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ const float *fir_float_create(fir_float_state_t *fir,
+static inline const float *fir_float_create(fir_float_state_t *fir,
                                                 const float *coeffs,
                                                 int taps)
 {
@@ -268,13 +268,13 @@ static __inline__ const float *fir_float_create(fir_float_state_t *fir,
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void fir_float_free(fir_float_state_t *fir)
+static inline void fir_float_free(fir_float_state_t *fir)
 {
     span_free(fir->history);
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t fir_float(fir_float_state_t *fir, int16_t sample)
+static inline int16_t fir_float(fir_float_state_t *fir, int16_t sample)
 {
     int i;
     float y;

--- a/src/spandsp/g711.h
+++ b/src/spandsp/g711.h
@@ -121,7 +121,7 @@ extern "C"
     \param linear The sample to encode.
     \return The u-law value.
 */
-static __inline__ uint8_t linear_to_ulaw(int linear)
+static inline uint8_t linear_to_ulaw(int linear)
 {
     uint8_t u_val;
     int mask;
@@ -162,7 +162,7 @@ static __inline__ uint8_t linear_to_ulaw(int linear)
     \param ulaw The u-law sample to decode.
     \return The linear value.
 */
-static __inline__ int16_t ulaw_to_linear(uint8_t ulaw)
+static inline int16_t ulaw_to_linear(uint8_t ulaw)
 {
     int t;
 
@@ -199,7 +199,7 @@ static __inline__ int16_t ulaw_to_linear(uint8_t ulaw)
     \param linear The sample to encode.
     \return The A-law value.
 */
-static __inline__ uint8_t linear_to_alaw(int linear)
+static inline uint8_t linear_to_alaw(int linear)
 {
     uint8_t a_val;
     int mask;
@@ -236,7 +236,7 @@ static __inline__ uint8_t linear_to_alaw(int linear)
     \param alaw The A-law sample to decode.
     \return The linear value.
 */
-static __inline__ int16_t alaw_to_linear(uint8_t alaw)
+static inline int16_t alaw_to_linear(uint8_t alaw)
 {
     int i;
     int seg;

--- a/src/spandsp/saturated.h
+++ b/src/spandsp/saturated.h
@@ -42,7 +42,7 @@ extern "C"
 {
 #endif
 
-static __inline__ int16_t saturate16(int32_t amp)
+static inline int16_t saturate16(int32_t amp)
 {
 #if defined(__GNUC__)  &&  (defined(__ARM_ARCH_6__)  ||  defined(__ARM_ARCH_7A__))
     int16_t z;
@@ -68,7 +68,7 @@ static __inline__ int16_t saturate16(int32_t amp)
 /*- End of function --------------------------------------------------------*/
 
 /*! Saturate to 15 bits, rather than the usual 16 bits. This is often a useful function. */
-static __inline__ int16_t saturate15(int32_t amp)
+static inline int16_t saturate15(int32_t amp)
 {
 #if defined(__GNUC__)  &&  (defined(__ARM_ARCH_6__)  ||  defined(__ARM_ARCH_7A__))
     int16_t z;
@@ -89,7 +89,7 @@ static __inline__ int16_t saturate15(int32_t amp)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint16_t saturateu16(int32_t amp)
+static inline uint16_t saturateu16(int32_t amp)
 {
 #if defined(__GNUC__)  &&  (defined(__ARM_ARCH_6__)  ||  defined(__ARM_ARCH_7A__))
     uint16_t z;
@@ -114,7 +114,7 @@ static __inline__ uint16_t saturateu16(int32_t amp)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint8_t saturateu8(int32_t amp)
+static inline uint8_t saturateu8(int32_t amp)
 {
 #if defined(__GNUC__)  &&  (defined(__ARM_ARCH_6__)  ||  defined(__ARM_ARCH_7A__))
     uint8_t z;
@@ -139,7 +139,7 @@ static __inline__ uint8_t saturateu8(int32_t amp)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t fsaturatef(float famp)
+static inline int16_t fsaturatef(float famp)
 {
     if (famp > (float) INT16_MAX)
         return INT16_MAX;
@@ -149,7 +149,7 @@ static __inline__ int16_t fsaturatef(float famp)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t fsaturate(double damp)
+static inline int16_t fsaturate(double damp)
 {
     if (damp > (double) INT16_MAX)
         return INT16_MAX;
@@ -160,7 +160,7 @@ static __inline__ int16_t fsaturate(double damp)
 /*- End of function --------------------------------------------------------*/
 
 /* Saturate to a 16 bit integer, using the fastest float to int conversion */
-static __inline__ int16_t ffastsaturatef(float famp)
+static inline int16_t ffastsaturatef(float famp)
 {
     if (famp > (float) INT16_MAX)
         return INT16_MAX;
@@ -171,7 +171,7 @@ static __inline__ int16_t ffastsaturatef(float famp)
 /*- End of function --------------------------------------------------------*/
 
 /* Saturate to a 16 bit integer, using the fastest double to int conversion */
-static __inline__ int16_t ffastsaturate(double damp)
+static inline int16_t ffastsaturate(double damp)
 {
     if (damp > (double) INT16_MAX)
         return INT16_MAX;
@@ -182,7 +182,7 @@ static __inline__ int16_t ffastsaturate(double damp)
 /*- End of function --------------------------------------------------------*/
 
 /* Saturate to a 16 bit integer, using the closest float to int conversion */
-static __inline__ float ffsaturatef(float famp)
+static inline float ffsaturatef(float famp)
 {
     if (famp > (float) INT16_MAX)
         return (float) INT16_MAX;
@@ -193,7 +193,7 @@ static __inline__ float ffsaturatef(float famp)
 /*- End of function --------------------------------------------------------*/
 
 /* Saturate to a 16 bit integer, using the closest double to int conversion */
-static __inline__ double ffsaturate(double famp)
+static inline double ffsaturate(double famp)
 {
     if (famp > (double) INT16_MAX)
         return (double) INT16_MAX;
@@ -203,7 +203,7 @@ static __inline__ double ffsaturate(double famp)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t sat_add16(int16_t x, int16_t y)
+static inline int16_t sat_add16(int16_t x, int16_t y)
 {
 #if defined(__GNUC__)  &&  (defined(__i386__)  ||  defined(__x86_64__))
     __asm__ __volatile__(" addw %[y],%[x];\n"
@@ -231,7 +231,7 @@ static __inline__ int16_t sat_add16(int16_t x, int16_t y)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int32_t sat_add32(int32_t x, int32_t y)
+static inline int32_t sat_add32(int32_t x, int32_t y)
 {
 #if defined(__GNUC__)  &&  (defined(__i386__)  ||  defined(__x86_64__))
     __asm__ __volatile__(" addl %[y],%[x];\n"
@@ -265,7 +265,7 @@ static __inline__ int32_t sat_add32(int32_t x, int32_t y)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t sat_sub16(int16_t x, int16_t y)
+static inline int16_t sat_sub16(int16_t x, int16_t y)
 {
 #if defined(__GNUC__)  &&  (defined(__i386__)  ||  defined(__x86_64__))
     __asm__ __volatile__(" subw %[y],%[x];\n"
@@ -291,7 +291,7 @@ static __inline__ int16_t sat_sub16(int16_t x, int16_t y)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int32_t sat_sub32(int32_t x, int32_t y)
+static inline int32_t sat_sub32(int32_t x, int32_t y)
 {
 #if defined(__GNUC__)  &&  (defined(__i386__)  ||  defined(__x86_64__))
     __asm__ __volatile__(" subl %[y],%[x];\n"
@@ -325,7 +325,7 @@ static __inline__ int32_t sat_sub32(int32_t x, int32_t y)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t sat_mul16(int16_t x, int16_t y)
+static inline int16_t sat_mul16(int16_t x, int16_t y)
 {
     int32_t z;
 
@@ -346,7 +346,7 @@ static __inline__ int16_t sat_mul16(int16_t x, int16_t y)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int32_t sat_mul32_16(int16_t x, int16_t y)
+static inline int32_t sat_mul32_16(int16_t x, int16_t y)
 {
     int32_t z;
 
@@ -365,7 +365,7 @@ static __inline__ int32_t sat_mul32_16(int16_t x, int16_t y)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int32_t sat_mac32_16(int32_t z, int16_t x, int16_t y)
+static inline int32_t sat_mac32_16(int32_t z, int16_t x, int16_t y)
 {
 #if defined(__GNUC__)  &&  (defined(__ARM_ARCH_6__)  ||  defined(__ARM_ARCH_7A__))
     int32_t product;
@@ -381,7 +381,7 @@ static __inline__ int32_t sat_mac32_16(int32_t z, int16_t x, int16_t y)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int32_t sat_msu32_16(int32_t z, int16_t x, int16_t y)
+static inline int32_t sat_msu32_16(int32_t z, int16_t x, int16_t y)
 {
 #if defined(__GNUC__)  &&  (defined(__ARM_ARCH_6__)  ||  defined(__ARM_ARCH_7A__))
     int32_t product;
@@ -397,7 +397,7 @@ static __inline__ int32_t sat_msu32_16(int32_t z, int16_t x, int16_t y)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int16_t sat_abs16(int16_t x)
+static inline int16_t sat_abs16(int16_t x)
 {
     if (x == INT16_MIN)
         return INT16_MAX;
@@ -405,7 +405,7 @@ static __inline__ int16_t sat_abs16(int16_t x)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int32_t sat_abs32(int32_t x)
+static inline int32_t sat_abs32(int32_t x)
 {
     if (x == INT32_MIN)
         return INT32_MAX;

--- a/src/spandsp/timing.h
+++ b/src/spandsp/timing.h
@@ -43,7 +43,7 @@ __declspec(naked) unsigned __int64 __cdecl rdtscll(void)
 /*- End of function --------------------------------------------------------*/
 #elif defined(__GNUC__)
 #if defined(__i386__)
-static __inline__ uint64_t rdtscll(void)
+static inline uint64_t rdtscll(void)
 {
     uint64_t now;
 
@@ -52,7 +52,7 @@ static __inline__ uint64_t rdtscll(void)
 }
 /*- End of function --------------------------------------------------------*/
 #elif defined(__x86_64__)
-static __inline__ uint64_t rdtscll(void)
+static inline uint64_t rdtscll(void)
 {
     uint32_t a;
     uint32_t d;
@@ -64,7 +64,7 @@ static __inline__ uint64_t rdtscll(void)
 }
 /*- End of function --------------------------------------------------------*/
 #else
-static __inline__ uint64_t rdtscll(void)
+static inline uint64_t rdtscll(void)
 {
     /* This architecture doesn't have a suitable timer */
     return 0llu;

--- a/src/spandsp/tone_detect.h
+++ b/src/spandsp/tone_detect.h
@@ -126,7 +126,7 @@ SPAN_DECLARE(float) goertzel_result(goertzel_state_t *s);
 /*! \brief Update the state of a Goertzel transform.
     \param s The Goertzel context.
     \param amp The sample to be transformed. */
-static __inline__ void goertzel_sample(goertzel_state_t *s, int16_t amp)
+static inline void goertzel_sample(goertzel_state_t *s, int16_t amp)
 {
 #if defined(SPANDSP_USE_FIXED_POINT)
     int16_t x;
@@ -169,9 +169,9 @@ static __inline__ void goertzel_sample(goertzel_state_t *s, int16_t amp)
     \param s The Goertzel context.
     \param amp The adjusted sample to be transformed. */
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ void goertzel_samplex(goertzel_state_t *s, int16_t amp)
+static inline void goertzel_samplex(goertzel_state_t *s, int16_t amp)
 #else
-static __inline__ void goertzel_samplex(goertzel_state_t *s, float amp)
+static inline void goertzel_samplex(goertzel_state_t *s, float amp)
 #endif
 {
 #if defined(SPANDSP_USE_FIXED_POINT)

--- a/src/spandsp/unaligned.h
+++ b/src/spandsp/unaligned.h
@@ -49,7 +49,7 @@ struct __dealign_uint64 { uint64_t datum; } __attribute__((packed));
 
 #if defined(__GNUC__)  ||  defined(__clang__)  ||  defined(_MSC_VER)
 /* If we just tell GCC what's going on, we can trust it to behave optimally */
-static __inline__ uint64_t get_unaligned_uint64(const void *p)
+static inline uint64_t get_unaligned_uint64(const void *p)
 {
     const struct __dealign_uint64 *pp = (const struct __dealign_uint64 *) p;
 
@@ -57,7 +57,7 @@ static __inline__ uint64_t get_unaligned_uint64(const void *p)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_unaligned_uint64(void *p, uint32_t datum)
+static inline void put_unaligned_uint64(void *p, uint32_t datum)
 {
     struct __dealign_uint64 *pp = (struct __dealign_uint64 *) p;
 
@@ -65,7 +65,7 @@ static __inline__ void put_unaligned_uint64(void *p, uint32_t datum)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint64_t get_net_unaligned_uint64(const void *p)
+static inline uint64_t get_net_unaligned_uint64(const void *p)
 {
     const struct __dealign_uint64 *pp = (const struct __dealign_uint64 *) p;
 
@@ -77,7 +77,7 @@ static __inline__ uint64_t get_net_unaligned_uint64(const void *p)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_net_unaligned_uint64(void *p, uint64_t datum)
+static inline void put_net_unaligned_uint64(void *p, uint64_t datum)
 {
     struct __dealign_uint64 *pp = (struct __dealign_uint64 *) p;
 
@@ -89,7 +89,7 @@ static __inline__ void put_net_unaligned_uint64(void *p, uint64_t datum)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint32_t get_unaligned_uint32(const void *p)
+static inline uint32_t get_unaligned_uint32(const void *p)
 {
     const struct __dealign_uint32 *pp = (const struct __dealign_uint32 *) p;
 
@@ -97,7 +97,7 @@ static __inline__ uint32_t get_unaligned_uint32(const void *p)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_unaligned_uint32(void *p, uint32_t datum)
+static inline void put_unaligned_uint32(void *p, uint32_t datum)
 {
     struct __dealign_uint32 *pp = (struct __dealign_uint32 *) p;
 
@@ -105,7 +105,7 @@ static __inline__ void put_unaligned_uint32(void *p, uint32_t datum)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint32_t get_net_unaligned_uint32(const void *p)
+static inline uint32_t get_net_unaligned_uint32(const void *p)
 {
     const struct __dealign_uint32 *pp = (const struct __dealign_uint32 *) p;
 
@@ -117,7 +117,7 @@ static __inline__ uint32_t get_net_unaligned_uint32(const void *p)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_net_unaligned_uint32(void *p, uint32_t datum)
+static inline void put_net_unaligned_uint32(void *p, uint32_t datum)
 {
     struct __dealign_uint32 *pp = (struct __dealign_uint32 *) p;
 
@@ -129,7 +129,7 @@ static __inline__ void put_net_unaligned_uint32(void *p, uint32_t datum)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint16_t get_unaligned_uint16(const void *p)
+static inline uint16_t get_unaligned_uint16(const void *p)
 {
     const struct __dealign_uint16 *pp = (const struct __dealign_uint16 *) p;
 
@@ -137,7 +137,7 @@ static __inline__ uint16_t get_unaligned_uint16(const void *p)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_unaligned_uint16(void *p, uint16_t datum)
+static inline void put_unaligned_uint16(void *p, uint16_t datum)
 {
     struct __dealign_uint16 *pp = (struct __dealign_uint16 *) p;
 
@@ -145,7 +145,7 @@ static __inline__ void put_unaligned_uint16(void *p, uint16_t datum)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint16_t get_net_unaligned_uint16(const void *p)
+static inline uint16_t get_net_unaligned_uint16(const void *p)
 {
     const struct __dealign_uint16 *pp = (const struct __dealign_uint16 *) p;
 
@@ -157,7 +157,7 @@ static __inline__ uint16_t get_net_unaligned_uint16(const void *p)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_net_unaligned_uint16(void *p, uint16_t datum)
+static inline void put_net_unaligned_uint16(void *p, uint16_t datum)
 {
     struct __dealign_uint16 *pp = (struct __dealign_uint16 *) p;
 
@@ -171,7 +171,7 @@ static __inline__ void put_net_unaligned_uint16(void *p, uint16_t datum)
 
 #elif defined(SOLARIS)  &&  defined(__sparc__)
 
-static __inline__ uint64_t get_unaligned_uint64(const void *p)
+static inline uint64_t get_unaligned_uint64(const void *p)
 {
     const uint8_t *cp = p;
 
@@ -179,7 +179,7 @@ static __inline__ uint64_t get_unaligned_uint64(const void *p)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_unaligned_uint64(void *p, uint64_t datum)
+static inline void put_unaligned_uint64(void *p, uint64_t datum)
 {
     const uint8_t *cp = p;
 
@@ -194,7 +194,7 @@ static __inline__ void put_unaligned_uint64(void *p, uint64_t datum)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint32_t get_unaligned_uint32(const void *p)
+static inline uint32_t get_unaligned_uint32(const void *p)
 {
     const uint8_t *cp = p;
 
@@ -202,7 +202,7 @@ static __inline__ uint32_t get_unaligned_uint32(const void *p)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_unaligned_uint32(void *p, uint32_t datum)
+static inline void put_unaligned_uint32(void *p, uint32_t datum)
 {
     const uint8_t *cp = p;
 
@@ -213,7 +213,7 @@ static __inline__ void put_unaligned_uint32(void *p, uint32_t datum)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint16_t get_unaligned_uint16(const void *p)
+static inline uint16_t get_unaligned_uint16(const void *p)
 {
     const uint8_t *cp = p;
 
@@ -221,7 +221,7 @@ static __inline__ uint16_t get_unaligned_uint16(const void *p)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_unaligned_uint16(void *p, uint16_t datum)
+static inline void put_unaligned_uint16(void *p, uint16_t datum)
 {
     uint8_t *cp = p;
 

--- a/src/spandsp/vector_int.h
+++ b/src/spandsp/vector_int.h
@@ -31,61 +31,61 @@ extern "C"
 {
 #endif
 
-static __inline__ void vec_copyi(int z[], const int x[], int n)
+static inline void vec_copyi(int z[], const int x[], int n)
 {
     memcpy(z, x, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void vec_copyi16(int16_t z[], const int16_t x[], int n)
+static inline void vec_copyi16(int16_t z[], const int16_t x[], int n)
 {
     memcpy(z, x, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void vec_copyi32(int32_t z[], const int32_t x[], int n)
+static inline void vec_copyi32(int32_t z[], const int32_t x[], int n)
 {
     memcpy(z, x, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void vec_movei(int z[], const int x[], int n)
+static inline void vec_movei(int z[], const int x[], int n)
 {
     memmove(z, x, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void vec_movei16(int16_t z[], const int16_t x[], int n)
+static inline void vec_movei16(int16_t z[], const int16_t x[], int n)
 {
     memmove(z, x, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void vec_movei32(int32_t z[], const int32_t x[], int n)
+static inline void vec_movei32(int32_t z[], const int32_t x[], int n)
 {
     memmove(z, x, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void vec_zeroi(int z[], int n)
+static inline void vec_zeroi(int z[], int n)
 {
     memset(z, 0, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void vec_zeroi16(int16_t z[], int n)
+static inline void vec_zeroi16(int16_t z[], int n)
 {
     memset(z, 0, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void vec_zeroi32(int32_t z[], int n)
+static inline void vec_zeroi32(int32_t z[], int n)
 {
     memset(z, 0, n*sizeof(z[0]));
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void vec_seti(int z[], int x, int n)
+static inline void vec_seti(int z[], int x, int n)
 {
     int i;
 
@@ -94,7 +94,7 @@ static __inline__ void vec_seti(int z[], int x, int n)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void vec_seti16(int16_t z[], int16_t x, int n)
+static inline void vec_seti16(int16_t z[], int16_t x, int n)
 {
     int i;
 
@@ -103,7 +103,7 @@ static __inline__ void vec_seti16(int16_t z[], int16_t x, int n)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void vec_seti32(int32_t z[], int32_t x, int n)
+static inline void vec_seti32(int32_t z[], int32_t x, int n)
 {
     int i;
 
@@ -143,7 +143,7 @@ SPAN_DECLARE(void) vec_circular_lmsi16(const int16_t x[], int16_t y[], int n, in
             than the ones being searched. */
 SPAN_DECLARE(int32_t) vec_min_maxi16(const int16_t x[], int n, int16_t out[]);
 
-static __inline__ int vec_norm2i16(const int16_t *vec, int len)
+static inline int vec_norm2i16(const int16_t *vec, int len)
 {
     int i;
     int sum;
@@ -155,7 +155,7 @@ static __inline__ int vec_norm2i16(const int16_t *vec, int len)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void vec_sari16(int16_t *vec, int len, int shift)
+static inline void vec_sari16(int16_t *vec, int len, int shift)
 {
     int i;
 
@@ -164,7 +164,7 @@ static __inline__ void vec_sari16(int16_t *vec, int len, int shift)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int vec_max_bitsi16(const int16_t *vec, int len)
+static inline int vec_max_bitsi16(const int16_t *vec, int len)
 {
     int i;
     int max;

--- a/src/t31.c
+++ b/src/t31.c
@@ -195,7 +195,7 @@ static int non_ecm_get(void *user_data, uint8_t buf[], int len);
 static void non_ecm_rx_status(void *user_data, int status);
 static void hdlc_rx_status(void *user_data, int status);
 
-static __inline__ void t31_set_at_rx_mode(t31_state_t *s, int new_mode)
+static inline void t31_set_at_rx_mode(t31_state_t *s, int new_mode)
 {
     s->at_state.at_rx_mode = new_mode;
 }
@@ -782,7 +782,7 @@ static void send_hdlc(void *user_data, const uint8_t *msg, int len)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int bits_to_us(t31_state_t *s, int bits)
+static inline int bits_to_us(t31_state_t *s, int bits)
 {
     if (!s->t38_fe.t38.pace_transmission  ||  s->t38_fe.tx_bit_rate == 0)
         return 0;
@@ -2286,7 +2286,7 @@ static int restart_modem(t31_state_t *s, int new_modem)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void dle_unstuff_hdlc(t31_state_t *s, const char *stuffed, int len)
+static inline void dle_unstuff_hdlc(t31_state_t *s, const char *stuffed, int len)
 {
     int i;
 
@@ -2334,7 +2334,7 @@ static __inline__ void dle_unstuff_hdlc(t31_state_t *s, const char *stuffed, int
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void dle_unstuff_fake_hdlc(t31_state_t *s, const char *stuffed, int len)
+static inline void dle_unstuff_fake_hdlc(t31_state_t *s, const char *stuffed, int len)
 {
     int i;
 
@@ -2374,7 +2374,7 @@ static __inline__ void dle_unstuff_fake_hdlc(t31_state_t *s, const char *stuffed
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void dle_unstuff(t31_state_t *s, const char *stuffed, int len)
+static inline void dle_unstuff(t31_state_t *s, const char *stuffed, int len)
 {
     int i;
 

--- a/src/t38_core.c
+++ b/src/t38_core.c
@@ -309,7 +309,7 @@ SPAN_DECLARE(int) t38_v34rate_to_bps(const uint8_t *data, int len)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int classify_seq_no_offset(int expected, int actual)
+static inline int classify_seq_no_offset(int expected, int actual)
 {
     /* Classify the mismatch between expected and actual sequence numbers
        according to whether the actual is a little in the past (late), a

--- a/src/t38_terminal.c
+++ b/src/t38_terminal.c
@@ -135,7 +135,7 @@ enum
     T38_TIMED_STEP_NO_SIGNAL = 0x60
 };
 
-static __inline__ int front_end_status(t38_terminal_state_t *s, int status)
+static inline int front_end_status(t38_terminal_state_t *s, int status)
 {
     t30_front_end_status(&s->t30, status);
     if (s->t38_fe.timed_step == T38_TIMED_STEP_NONE)
@@ -144,7 +144,7 @@ static __inline__ int front_end_status(t38_terminal_state_t *s, int status)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void hdlc_accept_frame(t38_terminal_state_t *s, const uint8_t *msg, int len, int ok)
+static inline void hdlc_accept_frame(t38_terminal_state_t *s, const uint8_t *msg, int len, int ok)
 {
     t30_hdlc_accept(&s->t30, msg, len, ok);
 }
@@ -633,7 +633,7 @@ static void send_hdlc(void *user_data, const uint8_t *msg, int len)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int bits_to_microseconds(t38_terminal_state_t *s, int bits)
+static inline int bits_to_microseconds(t38_terminal_state_t *s, int bits)
 {
     if (!s->t38_fe.t38.pace_transmission  ||  s->t38_fe.tx_bit_rate == 0)
         return 0;

--- a/src/t42.c
+++ b/src/t42.c
@@ -430,7 +430,7 @@ void set_gamut_from_code(logging_state_t *logging, lab_params_t *s, const uint8_
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void itu_to_lab(lab_params_t *s, cielab_t *lab, const uint8_t in[3])
+static inline void itu_to_lab(lab_params_t *s, cielab_t *lab, const uint8_t in[3])
 {
     uint8_t a;
     uint8_t b;
@@ -450,7 +450,7 @@ static __inline__ void itu_to_lab(lab_params_t *s, cielab_t *lab, const uint8_t 
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void lab_to_itu(lab_params_t *s, uint8_t out[3], const cielab_t *lab)
+static inline void lab_to_itu(lab_params_t *s, uint8_t out[3], const cielab_t *lab)
 {
     /* T.4 E.6.4 */
     out[0] = saturateu8(floorf(lab->L/s->range_L + s->offset_L));

--- a/src/t4_t6_decode.c
+++ b/src/t4_t6_decode.c
@@ -161,7 +161,7 @@ static int free_buffers(t4_t6_decode_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void add_run_to_row(t4_t6_decode_state_t *s)
+static inline void add_run_to_row(t4_t6_decode_state_t *s)
 {
     if (s->run_length >= 0)
     {
@@ -176,7 +176,7 @@ static __inline__ void add_run_to_row(t4_t6_decode_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void update_row_bit_info(t4_t6_decode_state_t *s)
+static inline void update_row_bit_info(t4_t6_decode_state_t *s)
 {
     if (s->row_bits > s->max_row_bits)
         s->max_row_bits = s->row_bits;
@@ -332,7 +332,7 @@ static int put_decoded_row(t4_t6_decode_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void drop_rx_bits(t4_t6_decode_state_t *s, int bits)
+static inline void drop_rx_bits(t4_t6_decode_state_t *s, int bits)
 {
     /* Only remove one bit right now. The rest need to be removed step by step,
        checking for a misaligned EOL along the way. This is time consuming, but
@@ -344,7 +344,7 @@ static __inline__ void drop_rx_bits(t4_t6_decode_state_t *s, int bits)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void force_drop_rx_bits(t4_t6_decode_state_t *s, int bits)
+static inline void force_drop_rx_bits(t4_t6_decode_state_t *s, int bits)
 {
     /* This should only be called to drop the bits of an EOL, as that is the
        only place where it is safe to drop them all at once. */

--- a/src/t4_t6_encode.c
+++ b/src/t4_t6_encode.c
@@ -399,7 +399,7 @@ static int free_buffers(t4_t6_encode_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int put_encoded_bits(t4_t6_encode_state_t *s, uint32_t bits, int length)
+static inline int put_encoded_bits(t4_t6_encode_state_t *s, uint32_t bits, int length)
 {
     /* We might be called with a large length value, to spew out a mass of zero bits for
        minimum row length padding. */
@@ -421,7 +421,7 @@ static __inline__ int put_encoded_bits(t4_t6_encode_state_t *s, uint32_t bits, i
  * Write the sequence of codes that describes the specified span of zero's or one's.
  * The appropriate table that holds the make-up and terminating codes is supplied.
  */
-static __inline__ int put_1d_span(t4_t6_encode_state_t *s, int32_t span, const t4_run_table_entry_t *tab)
+static inline int put_1d_span(t4_t6_encode_state_t *s, int32_t span, const t4_run_table_entry_t *tab)
 {
     const t4_run_table_entry_t *te;
 

--- a/src/t81_t82_arith_coding.c
+++ b/src/t81_t82_arith_coding.c
@@ -181,7 +181,7 @@ static const struct probability_estimation_s
     {0x59EB, 112 + 128, 111}
 };
 
-static __inline__ void output_stuffed_byte(t81_t82_arith_encode_state_t *s, int byte)
+static inline void output_stuffed_byte(t81_t82_arith_encode_state_t *s, int byte)
 {
     s->output_byte_handler(s->user_data, byte);
     if (byte == T81_T82_ESC)
@@ -190,7 +190,7 @@ static __inline__ void output_stuffed_byte(t81_t82_arith_encode_state_t *s, int 
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void byteout(t81_t82_arith_encode_state_t *s)
+static inline void byteout(t81_t82_arith_encode_state_t *s)
 {
     uint32_t temp;
 
@@ -232,7 +232,7 @@ static __inline__ void byteout(t81_t82_arith_encode_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void renorme(t81_t82_arith_encode_state_t *s)
+static inline void renorme(t81_t82_arith_encode_state_t *s)
 {
     /* T.82 figure 25 - RENORME */
     do

--- a/src/t85_encode.c
+++ b/src/t85_encode.c
@@ -98,7 +98,7 @@ static void output_byte(void *user_data, int byte)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void output_esc_code(t85_encode_state_t *s, int code)
+static inline void output_esc_code(t85_encode_state_t *s, int code)
 {
     uint8_t buf[2];
 
@@ -108,7 +108,7 @@ static __inline__ void output_esc_code(t85_encode_state_t *s, int code)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void output_newlen(t85_encode_state_t *s)
+static inline void output_newlen(t85_encode_state_t *s)
 {
     uint8_t buf[6];
 
@@ -130,7 +130,7 @@ static __inline__ void output_newlen(t85_encode_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void output_comment(t85_encode_state_t *s)
+static inline void output_comment(t85_encode_state_t *s)
 {
     uint8_t buf[6];
 
@@ -148,7 +148,7 @@ static __inline__ void output_comment(t85_encode_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void output_atmove(t85_encode_state_t *s)
+static inline void output_atmove(t85_encode_state_t *s)
 {
     uint8_t buf[8];
 

--- a/src/testcpuid.c
+++ b/src/testcpuid.c
@@ -57,7 +57,7 @@ enum
 };
 
 /* Standard macro to see if a specific flag is changeable */
-static __inline__ int flag_is_changeable_p(uint32_t flag)
+static inline int flag_is_changeable_p(uint32_t flag)
 {
     uint32_t f1;
     uint32_t f2;

--- a/src/time_scale.c
+++ b/src/time_scale.c
@@ -63,7 +63,7 @@
     OverLap and Add (PICOLA) method, developed by Morita Naotaka.
  */
 
-static __inline__ int amdf_pitch(int min_pitch, int max_pitch, int16_t amp[], int len)
+static inline int amdf_pitch(int min_pitch, int max_pitch, int16_t amp[], int len)
 {
     int i;
     int j;
@@ -91,7 +91,7 @@ static __inline__ int amdf_pitch(int min_pitch, int max_pitch, int16_t amp[], in
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void overlap_add(int16_t amp1[], int16_t amp2[], int len)
+static inline void overlap_add(int16_t amp1[], int16_t amp2[], int len)
 {
     int i;
     float weight;

--- a/src/v17rx.c
+++ b/src/v17rx.c
@@ -266,7 +266,7 @@ static void equalizer_reset(v17_rx_state_t *s)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINTx)
-static __inline__ complexi16_t equalizer_get(v17_rx_state_t *s)
+static inline complexi16_t equalizer_get(v17_rx_state_t *s)
 {
     complexi32_t zz;
     complexi16_t z;
@@ -278,7 +278,7 @@ static __inline__ complexi16_t equalizer_get(v17_rx_state_t *s)
     return z;
 }
 #else
-static __inline__ complexf_t equalizer_get(v17_rx_state_t *s)
+static inline complexf_t equalizer_get(v17_rx_state_t *s)
 {
     /* Get the next equalized value. */
     return cvec_circular_dot_prodf(s->eq_buf, s->eq_coeff, V17_EQUALIZER_LEN, s->eq_step);
@@ -313,9 +313,9 @@ static void tune_equalizer(v17_rx_state_t *s, const complexf_t *z, const complex
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINTx)
-static __inline__ void track_carrier(v17_rx_state_t *s, const complexi16_t *z, const complexi16_t *target)
+static inline void track_carrier(v17_rx_state_t *s, const complexi16_t *z, const complexi16_t *target)
 #else
-static __inline__ void track_carrier(v17_rx_state_t *s, const complexf_t *z, const complexf_t *target)
+static inline void track_carrier(v17_rx_state_t *s, const complexf_t *z, const complexf_t *target)
 #endif
 {
 #if defined(SPANDSP_USE_FIXED_POINTx)
@@ -356,7 +356,7 @@ static int descramble(v17_rx_state_t *s, int in_bit)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_bit(v17_rx_state_t *s, int bit)
+static inline void put_bit(v17_rx_state_t *s, int bit)
 {
     int out_bit;
 
@@ -379,13 +379,13 @@ static __inline__ void put_bit(v17_rx_state_t *s, int bit)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINTx)
-static __inline__ uint32_t dist_sq(const complexi32_t *x, const complexi32_t *y)
+static inline uint32_t dist_sq(const complexi32_t *x, const complexi32_t *y)
 {
     return (int32_t) (x->re - y->re)*(x->re - y->re) + (int32_t) (x->im - y->im)*(x->im - y->im);
 }
 /*- End of function --------------------------------------------------------*/
 #else
-static __inline__ float dist_sq(const complexf_t *x, const complexf_t *y)
+static inline float dist_sq(const complexf_t *x, const complexf_t *y)
 {
     return (x->re - y->re)*(x->re - y->re) + (x->im - y->im)*(x->im - y->im);
 }
@@ -1133,7 +1133,7 @@ static void process_half_baud(v17_rx_state_t *s, const complexf_t *sample)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int signal_detect(v17_rx_state_t *s, int16_t amp)
+static inline int signal_detect(v17_rx_state_t *s, int16_t amp)
 {
     int16_t diff;
     int16_t x;

--- a/src/v17tx.c
+++ b/src/v17tx.c
@@ -106,7 +106,7 @@
 /*! The 16 bit pattern used in the bridge section of the training sequence */
 #define V17_BRIDGE_WORD                 0x8880
 
-static __inline__ int scramble(v17_tx_state_t *s, int in_bit)
+static inline int scramble(v17_tx_state_t *s, int in_bit)
 {
     int out_bit;
 
@@ -119,9 +119,9 @@ static __inline__ int scramble(v17_tx_state_t *s, int in_bit)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ complexi16_t training_get(v17_tx_state_t *s)
+static inline complexi16_t training_get(v17_tx_state_t *s)
 #else
-static __inline__ complexf_t training_get(v17_tx_state_t *s)
+static inline complexf_t training_get(v17_tx_state_t *s)
 #endif
 {
     static const int cdba_to_abcd[4] =
@@ -184,7 +184,7 @@ static __inline__ complexf_t training_get(v17_tx_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int diff_and_convolutional_encode(v17_tx_state_t *s, int q)
+static inline int diff_and_convolutional_encode(v17_tx_state_t *s, int q)
 {
     static const uint8_t v32bis_4800_differential_encoder[4][4] =
     {
@@ -239,9 +239,9 @@ static int fake_get_bit(void *user_data)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ complexi16_t getbaud(v17_tx_state_t *s)
+static inline complexi16_t getbaud(v17_tx_state_t *s)
 #else
-static __inline__ complexf_t getbaud(v17_tx_state_t *s)
+static inline complexf_t getbaud(v17_tx_state_t *s)
 #endif
 {
     int i;

--- a/src/v22bis_rx.c
+++ b/src/v22bis_rx.c
@@ -218,7 +218,7 @@ static void equalizer_reset(v22bis_state_t *s)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ complexi16_t equalizer_get(v22bis_state_t *s)
+static inline complexi16_t equalizer_get(v22bis_state_t *s)
 {
     complexi32_t zz;
     complexi16_t z;
@@ -230,7 +230,7 @@ static __inline__ complexi16_t equalizer_get(v22bis_state_t *s)
     return z;
 }
 #else
-static __inline__ complexf_t equalizer_get(v22bis_state_t *s)
+static inline complexf_t equalizer_get(v22bis_state_t *s)
 {
     /* Get the next equalized value. */
     return cvec_circular_dot_prodf(s->rx.eq_buf, s->rx.eq_coeff, V22BIS_EQUALIZER_LEN, s->rx.eq_step);
@@ -264,9 +264,9 @@ static void tune_equalizer(v22bis_state_t *s, const complexf_t *z, const complex
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ void track_carrier(v22bis_state_t *s, const complexi16_t *z, const complexi16_t *target)
+static inline void track_carrier(v22bis_state_t *s, const complexi16_t *z, const complexi16_t *target)
 #else
-static __inline__ void track_carrier(v22bis_state_t *s, const complexf_t *z, const complexf_t *target)
+static inline void track_carrier(v22bis_state_t *s, const complexf_t *z, const complexf_t *target)
 #endif
 {
 #if defined(SPANDSP_USE_FIXED_POINT)
@@ -304,7 +304,7 @@ static __inline__ void track_carrier(v22bis_state_t *s, const complexf_t *z, con
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int descramble(v22bis_state_t *s, int bit)
+static inline int descramble(v22bis_state_t *s, int bit)
 {
     int out_bit;
 
@@ -328,7 +328,7 @@ static __inline__ int descramble(v22bis_state_t *s, int bit)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_bit(v22bis_state_t *s, int bit)
+static inline void put_bit(v22bis_state_t *s, int bit)
 {
     int out_bit;
 
@@ -378,7 +378,7 @@ static int decode_baudx(v22bis_state_t *s, int nearest)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void symbol_sync(v22bis_state_t *s)
+static inline void symbol_sync(v22bis_state_t *s)
 {
 #if defined(SPANDSP_USE_FIXED_POINT)
     int32_t p;
@@ -457,9 +457,9 @@ static __inline__ void symbol_sync(v22bis_state_t *s)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ void process_half_baud(v22bis_state_t *s, const complexi16_t *sample)
+static inline void process_half_baud(v22bis_state_t *s, const complexi16_t *sample)
 #else
-static __inline__ void process_half_baud(v22bis_state_t *s, const complexf_t *sample)
+static inline void process_half_baud(v22bis_state_t *s, const complexf_t *sample)
 #endif
 {
 #if defined(SPANDSP_USE_FIXED_POINT)

--- a/src/v22bis_tx.c
+++ b/src/v22bis_tx.c
@@ -410,7 +410,7 @@ static int fake_get_bit(void *user_data)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int scramble(v22bis_state_t *s, int bit)
+static inline int scramble(v22bis_state_t *s, int bit)
 {
     int out_bit;
 
@@ -432,7 +432,7 @@ static __inline__ int scramble(v22bis_state_t *s, int bit)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int get_scrambled_bit(v22bis_state_t *s)
+static inline int get_scrambled_bit(v22bis_state_t *s)
 {
     int bit;
 

--- a/src/v27ter_rx.c
+++ b/src/v27ter_rx.c
@@ -241,7 +241,7 @@ static void equalizer_reset(v27ter_rx_state_t *s)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ complexi16_t equalizer_get(v27ter_rx_state_t *s)
+static inline complexi16_t equalizer_get(v27ter_rx_state_t *s)
 {
     complexi32_t zz;
     complexi16_t z;
@@ -253,7 +253,7 @@ static __inline__ complexi16_t equalizer_get(v27ter_rx_state_t *s)
     return z;
 }
 #else
-static __inline__ complexf_t equalizer_get(v27ter_rx_state_t *s)
+static inline complexf_t equalizer_get(v27ter_rx_state_t *s)
 {
     /* Get the next equalized value. */
     return cvec_circular_dot_prodf(s->eq_buf, s->eq_coeff, V27TER_EQUALIZER_LEN, s->eq_step);
@@ -287,9 +287,9 @@ static void tune_equalizer(v27ter_rx_state_t *s, const complexf_t *z, const comp
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ void track_carrier(v27ter_rx_state_t *s, const complexi16_t *z, const complexi16_t *target)
+static inline void track_carrier(v27ter_rx_state_t *s, const complexi16_t *z, const complexi16_t *target)
 #else
-static __inline__ void track_carrier(v27ter_rx_state_t *s, const complexf_t *z, const complexf_t *target)
+static inline void track_carrier(v27ter_rx_state_t *s, const complexf_t *z, const complexf_t *target)
 #endif
 {
 #if defined(SPANDSP_USE_FIXED_POINT)
@@ -315,9 +315,9 @@ static __inline__ void track_carrier(v27ter_rx_state_t *s, const complexf_t *z, 
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ int find_quadrant(const complexi16_t *z)
+static inline int find_quadrant(const complexi16_t *z)
 #else
-static __inline__ int find_quadrant(const complexf_t *z)
+static inline int find_quadrant(const complexf_t *z)
 #endif
 {
     int b1;
@@ -331,9 +331,9 @@ static __inline__ int find_quadrant(const complexf_t *z)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ int find_octant(complexi16_t *z)
+static inline int find_octant(complexi16_t *z)
 #else
-static __inline__ int find_octant(complexf_t *z)
+static inline int find_octant(complexf_t *z)
 #endif
 {
 #if defined(SPANDSP_USE_FIXED_POINT)
@@ -374,7 +374,7 @@ static __inline__ int find_octant(complexf_t *z)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int descramble(v27ter_rx_state_t *s, int in_bit)
+static inline int descramble(v27ter_rx_state_t *s, int in_bit)
 {
     int out_bit;
 
@@ -412,7 +412,7 @@ static __inline__ int descramble(v27ter_rx_state_t *s, int in_bit)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_bit(v27ter_rx_state_t *s, int bit)
+static inline void put_bit(v27ter_rx_state_t *s, int bit)
 {
     int out_bit;
 
@@ -483,7 +483,7 @@ static void decode_baud(v27ter_rx_state_t *s, complexf_t *z)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void symbol_sync(v27ter_rx_state_t *s)
+static inline void symbol_sync(v27ter_rx_state_t *s)
 {
 #if defined(SPANDSP_USE_FIXED_POINT)
     int32_t p;
@@ -525,9 +525,9 @@ static __inline__ void symbol_sync(v27ter_rx_state_t *s)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ void process_half_baud(v27ter_rx_state_t *s, const complexi16_t *sample)
+static inline void process_half_baud(v27ter_rx_state_t *s, const complexi16_t *sample)
 #else
-static __inline__ void process_half_baud(v27ter_rx_state_t *s, const complexf_t *sample)
+static inline void process_half_baud(v27ter_rx_state_t *s, const complexf_t *sample)
 #endif
 {
     static const int abab_pos[2] = {0, 4};
@@ -781,7 +781,7 @@ static __inline__ void process_half_baud(v27ter_rx_state_t *s, const complexf_t 
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int signal_detect(v27ter_rx_state_t *s, int16_t amp)
+static inline int signal_detect(v27ter_rx_state_t *s, int16_t amp)
 {
     int16_t diff;
     int16_t x;

--- a/src/v27ter_tx.c
+++ b/src/v27ter_tx.c
@@ -100,7 +100,7 @@ static int fake_get_bit(void *user_data)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int scramble(v27ter_tx_state_t *s, int in_bit)
+static inline int scramble(v27ter_tx_state_t *s, int in_bit)
 {
     int out_bit;
 
@@ -125,7 +125,7 @@ static __inline__ int scramble(v27ter_tx_state_t *s, int in_bit)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int get_scrambled_bit(v27ter_tx_state_t *s)
+static inline int get_scrambled_bit(v27ter_tx_state_t *s)
 {
     int bit;
 

--- a/src/v29rx.c
+++ b/src/v29rx.c
@@ -246,7 +246,7 @@ static void equalizer_reset(v29_rx_state_t *s)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ complexi16_t equalizer_get(v29_rx_state_t *s)
+static inline complexi16_t equalizer_get(v29_rx_state_t *s)
 {
     complexi32_t zz;
     complexi16_t z;
@@ -258,7 +258,7 @@ static __inline__ complexi16_t equalizer_get(v29_rx_state_t *s)
     return z;
 }
 #else
-static __inline__ complexf_t equalizer_get(v29_rx_state_t *s)
+static inline complexf_t equalizer_get(v29_rx_state_t *s)
 {
     /* Get the next equalized value. */
     return cvec_circular_dot_prodf(s->eq_buf, s->eq_coeff, V29_EQUALIZER_LEN, s->eq_step);
@@ -292,9 +292,9 @@ static void tune_equalizer(v29_rx_state_t *s, const complexf_t *z, const complex
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ void track_carrier(v29_rx_state_t *s, const complexi16_t *z, const complexi16_t *target)
+static inline void track_carrier(v29_rx_state_t *s, const complexi16_t *z, const complexi16_t *target)
 #else
-static __inline__ void track_carrier(v29_rx_state_t *s, const complexf_t *z, const complexf_t *target)
+static inline void track_carrier(v29_rx_state_t *s, const complexf_t *z, const complexf_t *target)
 #endif
 {
 #if defined(SPANDSP_USE_FIXED_POINT)
@@ -332,9 +332,9 @@ static __inline__ void track_carrier(v29_rx_state_t *s, const complexf_t *z, con
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ int find_quadrant(const complexi16_t *z)
+static inline int find_quadrant(const complexi16_t *z)
 #else
-static __inline__ int find_quadrant(const complexf_t *z)
+static inline int find_quadrant(const complexf_t *z)
 #endif
 {
     int b1;
@@ -362,7 +362,7 @@ static int scrambled_training_bit(v29_rx_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int descramble(v29_rx_state_t *s, int in_bit)
+static inline int descramble(v29_rx_state_t *s, int in_bit)
 {
     int out_bit;
 
@@ -375,7 +375,7 @@ static __inline__ int descramble(v29_rx_state_t *s, int in_bit)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_bit(v29_rx_state_t *s, int bit)
+static inline void put_bit(v29_rx_state_t *s, int bit)
 {
     int out_bit;
 
@@ -785,7 +785,7 @@ static void process_half_baud(v29_rx_state_t *s, complexf_t *sample)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int signal_detect(v29_rx_state_t *s, int16_t amp)
+static inline int signal_detect(v29_rx_state_t *s, int16_t amp)
 {
     int16_t diff;
     int16_t x;

--- a/src/v29tx.c
+++ b/src/v29tx.c
@@ -100,7 +100,7 @@ static int fake_get_bit(void *user_data)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int get_scrambled_bit(v29_tx_state_t *s)
+static inline int get_scrambled_bit(v29_tx_state_t *s)
 {
     int bit;
     int out_bit;
@@ -124,9 +124,9 @@ static __inline__ int get_scrambled_bit(v29_tx_state_t *s)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ complexi16_t getbaud(v29_tx_state_t *s)
+static inline complexi16_t getbaud(v29_tx_state_t *s)
 #else
-static __inline__ complexf_t getbaud(v29_tx_state_t *s)
+static inline complexf_t getbaud(v29_tx_state_t *s)
 #endif
 {
     static const int phase_steps_9600[8] =

--- a/src/v34rx.c
+++ b/src/v34rx.c
@@ -758,7 +758,7 @@ static void viterbi_trace_back(viterbi_t *s, complexi16_t y[2])
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ float exact_baud_rate(int symbol_rate_code)
+static inline float exact_baud_rate(int symbol_rate_code)
 {
     float a;
     float c;
@@ -769,7 +769,7 @@ static __inline__ float exact_baud_rate(int symbol_rate_code)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ float carrier_frequency(int symbol_rate_code, int low_high)
+static inline float carrier_frequency(int symbol_rate_code, int low_high)
 {
     float d;
     float e;
@@ -1440,7 +1440,7 @@ span_log(s->logging, SPAN_LOG_FLOW, "Signal up\n");
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void cc_symbol_sync(v34_rx_state_t *s)
+static inline void cc_symbol_sync(v34_rx_state_t *s)
 {
     int i;
 #if defined(SPANDSP_USE_FIXED_POINT)
@@ -1510,7 +1510,7 @@ static __inline__ void cc_symbol_sync(v34_rx_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void pri_symbol_sync(v34_rx_state_t *s)
+static inline void pri_symbol_sync(v34_rx_state_t *s)
 {
     int i;
 #if defined(SPANDSP_USE_FIXED_POINT)
@@ -1676,7 +1676,7 @@ static void equalizer_reset(v34_rx_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complexf_t equalizer_get(v34_rx_state_t *s)
+static inline complexf_t equalizer_get(v34_rx_state_t *s)
 {
     int i;
     int p;
@@ -1741,7 +1741,7 @@ static void track_carrier(v34_rx_state_t *s, const complexf_t *z, const complexf
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void put_bit(v34_rx_state_t *s, int bit)
+static inline void put_bit(v34_rx_state_t *s, int bit)
 {
     int out_bit;
 
@@ -1765,13 +1765,13 @@ static __inline__ void put_bit(v34_rx_state_t *s, int bit)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ uint32_t dist_sq(const complexi_t *x, const complexi_t *y)
+static inline uint32_t dist_sq(const complexi_t *x, const complexi_t *y)
 {
     return (x->re - y->re)*(x->re - y->re) + (x->im - y->im)*(x->im - y->im);
 }
 /*- End of function --------------------------------------------------------*/
 #else
-static __inline__ float dist_sq(const complexf_t *x, const complexf_t *y)
+static inline float dist_sq(const complexf_t *x, const complexf_t *y)
 {
     return (x->re - y->re)*(x->re - y->re) + (x->im - y->im)*(x->im - y->im);
 }
@@ -1780,13 +1780,13 @@ static __inline__ float dist_sq(const complexf_t *x, const complexf_t *y)
 
 #endif
 
-static __inline__ complex_sig_t training_get(v34_tx_state_t *s)
+static inline complex_sig_t training_get(v34_tx_state_t *s)
 {
     return zero;
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complex_sig_t connect_sequence_get(v34_tx_state_t *s)
+static inline complex_sig_t connect_sequence_get(v34_tx_state_t *s)
 {
     return zero;
 }

--- a/src/v34tx.c
+++ b/src/v34tx.c
@@ -331,7 +331,7 @@ static void first_alt_baud_init(v34_state_t *s);
 static void second_alt_baud_init(v34_state_t *s);
 static void sh_baud_init(v34_state_t *s);
 
-static __inline__ int scramble(v34_tx_state_t *s, int in_bit)
+static inline int scramble(v34_tx_state_t *s, int in_bit)
 {
     int out_bit;
 
@@ -1468,7 +1468,7 @@ SPAN_DECLARE(int) v34_get_mapping_frame(v34_tx_state_t *s, int16_t bits[16])
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ float exact_baud_rate(int symbol_rate_code)
+static inline float exact_baud_rate(int symbol_rate_code)
 {
     float a;
     float c;
@@ -1479,7 +1479,7 @@ static __inline__ float exact_baud_rate(int symbol_rate_code)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ float carrier_frequency(int symbol_rate_code, int low_high)
+static inline float carrier_frequency(int symbol_rate_code, int low_high)
 {
     float d;
     float e;
@@ -2657,26 +2657,26 @@ static void sh_baud_init(v34_state_t *s)
 /*- End of function --------------------------------------------------------*/
 
 #if defined(SPANDSP_USE_FIXED_POINT)
-static __inline__ uint32_t dist_sq(const complexi_t *x, const complexi_t *y)
+static inline uint32_t dist_sq(const complexi_t *x, const complexi_t *y)
 {
     return (x->re - y->re)*(x->re - y->re) + (x->im - y->im)*(x->im - y->im);
 }
 /*- End of function --------------------------------------------------------*/
 #else
-static __inline__ float dist_sq(const complexf_t *x, const complexf_t *y)
+static inline float dist_sq(const complexf_t *x, const complexf_t *y)
 {
     return (x->re - y->re)*(x->re - y->re) + (x->im - y->im)*(x->im - y->im);
 }
 /*- End of function --------------------------------------------------------*/
 #endif
 
-static __inline__ complex_sig_t training_get(v34_tx_state_t *s)
+static inline complex_sig_t training_get(v34_tx_state_t *s)
 {
     return zero;
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ complex_sig_t connect_sequence_get(v34_tx_state_t *s)
+static inline complex_sig_t connect_sequence_get(v34_tx_state_t *s)
 {
     return zero;
 }

--- a/src/v42.c
+++ b/src/v42.c
@@ -262,7 +262,7 @@ static int tx_supervisory_frame(lapm_state_t *s, uint8_t addr, uint8_t ctrl, uin
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int set_param(int param, int value, int def)
+static inline int set_param(int param, int value, int def)
 {
     if ((value < def  &&  param >= def)  ||  (value >= def  &&  param < def))
         return def;
@@ -507,14 +507,14 @@ static void t400_expired(v42_state_t *ss)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void t400_start(v42_state_t *s)
+static inline void t400_start(v42_state_t *s)
 {
     s->bit_timer = ms_to_bits(s, T_400);
     s->bit_timer_func = t400_expired;
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void t400_stop(v42_state_t *s)
+static inline void t400_stop(v42_state_t *s)
 {
     s->bit_timer = 0;
 }
@@ -567,7 +567,7 @@ static void t401_expired(v42_state_t *ss)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void t401_start(v42_state_t *s)
+static inline void t401_start(v42_state_t *s)
 {
     s->bit_timer = ms_to_bits(s, T_401);
     s->bit_timer_func = t401_expired;
@@ -575,7 +575,7 @@ static __inline__ void t401_start(v42_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void t401_stop(v42_state_t *s)
+static inline void t401_stop(v42_state_t *s)
 {
     s->bit_timer = 0;
     s->lapm.retry_count = 0;
@@ -596,7 +596,7 @@ static void t403_expired(v42_state_t *ss)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void t401_stop_t403_start(v42_state_t *s)
+static inline void t401_stop_t403_start(v42_state_t *s)
 {
     s->bit_timer = ms_to_bits(s, T_403);
     s->bit_timer_func = t403_expired;

--- a/src/v42bis.c
+++ b/src/v42bis.c
@@ -86,7 +86,7 @@ enum
     V42BIS_RESET = 2        /* Force reinitialisation */
 };
 
-static __inline__ void push_octet(v42bis_comp_state_t *s, int octet)
+static inline void push_octet(v42bis_comp_state_t *s, int octet)
 {
     s->output_buf[s->output_octet_count++] = (uint8_t) octet;
     if (s->output_octet_count >= s->max_output_len)
@@ -97,7 +97,7 @@ static __inline__ void push_octet(v42bis_comp_state_t *s, int octet)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void push_octets(v42bis_comp_state_t *s, const uint8_t buf[], int len)
+static inline void push_octets(v42bis_comp_state_t *s, const uint8_t buf[], int len)
 {
     int i;
     int chunk;
@@ -120,7 +120,7 @@ static __inline__ void push_octets(v42bis_comp_state_t *s, const uint8_t buf[], 
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void push_compressed_code(v42bis_comp_state_t *s, int code)
+static inline void push_compressed_code(v42bis_comp_state_t *s, int code)
 {
     s->bit_buffer |= code << s->bit_count;
     s->bit_count += s->v42bis_parm_c2;
@@ -133,7 +133,7 @@ static __inline__ void push_compressed_code(v42bis_comp_state_t *s, int code)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void push_octet_alignment(v42bis_comp_state_t *s)
+static inline void push_octet_alignment(v42bis_comp_state_t *s)
 {
     if ((s->bit_count & 7))
     {
@@ -148,7 +148,7 @@ static __inline__ void push_octet_alignment(v42bis_comp_state_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ void flush_octets(v42bis_comp_state_t *s)
+static inline void flush_octets(v42bis_comp_state_t *s)
 {
     if (s->output_octet_count > 0)
     {

--- a/tests/bit_operations_tests.c
+++ b/tests/bit_operations_tests.c
@@ -46,7 +46,7 @@ their operation with very dumb brute force versions of the same functionality.
 uint8_t from[1000000];
 uint8_t to[1000000];
 
-static __inline__ int top_bit_dumb(unsigned int data)
+static inline int top_bit_dumb(unsigned int data)
 {
     int i;
 
@@ -64,7 +64,7 @@ static __inline__ int top_bit_dumb(unsigned int data)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int bottom_bit_dumb(unsigned int data)
+static inline int bottom_bit_dumb(unsigned int data)
 {
     int i;
 
@@ -82,7 +82,7 @@ static __inline__ int bottom_bit_dumb(unsigned int data)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint8_t bit_reverse8_dumb(uint8_t data)
+static inline uint8_t bit_reverse8_dumb(uint8_t data)
 {
     int i;
     int result;
@@ -98,7 +98,7 @@ static __inline__ uint8_t bit_reverse8_dumb(uint8_t data)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint32_t bit_reverse_4bytes_dumb(uint32_t data)
+static inline uint32_t bit_reverse_4bytes_dumb(uint32_t data)
 {
     int i;
     uint32_t result;
@@ -114,7 +114,7 @@ static __inline__ uint32_t bit_reverse_4bytes_dumb(uint32_t data)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint16_t bit_reverse16_dumb(uint16_t data)
+static inline uint16_t bit_reverse16_dumb(uint16_t data)
 {
     int i;
     uint16_t result;
@@ -130,7 +130,7 @@ static __inline__ uint16_t bit_reverse16_dumb(uint16_t data)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint32_t bit_reverse32_dumb(uint32_t data)
+static inline uint32_t bit_reverse32_dumb(uint32_t data)
 {
     int i;
     uint32_t result;
@@ -146,7 +146,7 @@ static __inline__ uint32_t bit_reverse32_dumb(uint32_t data)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int parity8_dumb(uint8_t x)
+static inline int parity8_dumb(uint8_t x)
 {
     uint8_t y;
     int i;
@@ -161,7 +161,7 @@ static __inline__ int parity8_dumb(uint8_t x)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ int one_bits32_dumb(uint32_t x)
+static inline int one_bits32_dumb(uint32_t x)
 {
     int i;
     int bits;

--- a/tests/t42_tests.c
+++ b/tests/t42_tests.c
@@ -61,7 +61,7 @@ lab_params_t lab_param;
 
 int write_row = 0;
 
-static __inline__ uint16_t pack_16(uint8_t *s)
+static inline uint16_t pack_16(uint8_t *s)
 {
     uint16_t value;
 
@@ -70,7 +70,7 @@ static __inline__ uint16_t pack_16(uint8_t *s)
 }
 /*- End of function --------------------------------------------------------*/
 
-static __inline__ uint32_t pack_32(uint8_t *s)
+static inline uint32_t pack_32(uint8_t *s)
 {
     uint32_t value;
 


### PR DESCRIPTION
"inline" was defined in C99 and is supported by Visual C++ 2015 and possibly earlier versions. Replace occurrences of "__inline__" with "inline" and remove some unneeded #defines.