### PR TITLE
Fixes cross compiling / do AC_CHECK_LIB to search for libxml

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,54 +55,7 @@ AC_LANG([C])
 
 AX_COMPILER_VENDOR
 
-if test "${build}" != "${host}"
-then
-    # If we are doing a Canadian Cross, in which the host and build systems
-    # are not the same, we set reasonable default values for the tools.
-
-    CC_FOR_BUILD=${CC_FOR_BUILD-gcc}
-    CPPFLAGS_FOR_BUILD="\$(CPPFLAGS)"
-    CC=${CC-${host_alias}-gcc}
-    CFLAGS=${CFLAGS-"-g -O2"}
-    CXX=${CXX-${host_alias}-c++}
-    CXXFLAGS=${CXXFLAGS-"-g -O2"}
-else
-    # Set reasonable default values for some tools even if not Canadian.
-    # Of course, these are different reasonable default values, originally
-    # specified directly in the Makefile.
-    # We don't export, so that autoconf can do its job.
-    # Note that all these settings are above the fragment inclusion point
-    # in Makefile.in, so can still be overridden by fragments.
-    # This is all going to change when we autoconfiscate...
-    CC_FOR_BUILD="\$(CC)"
-    CPPFLAGS_FOR_BUILD="\$(CPPFLAGS)"
-    AC_PROG_CC
-
-    # We must set the default linker to the linker used by gcc for the correct
-    # operation of libtool.  If LD is not defined and we are using gcc, try to
-    # set the LD default to the ld used by gcc.
-    if test -z "$LD"
-    then
-        if test "$GCC" = yes
-        then
-            case $build in
-            *-*-mingw*)
-                gcc_prog_ld=`$CC -print-prog-name=ld 2>&1 | tr -d '\015'` ;;
-            *)
-                gcc_prog_ld=`$CC -print-prog-name=ld 2>&1` ;;
-            esac
-            case $gcc_prog_ld in
-            # Accept absolute paths.
-            [[\\/]* | [A-Za-z]:[\\/]*)]
-                LD="$gcc_prog_ld" ;;
-            esac
-        fi
-    fi
-
-    CXX=${CXX-"c++"}
-    CFLAGS=${CFLAGS-"-g -O2"}
-    CXXFLAGS=${CXXFLAGS-"-g -O2"}
-fi
+AX_PROG_CC_FOR_BUILD
 
 AC_DEFUN([REMOVE_FROM_VAR],[
     new_val=""

--- a/configure.ac
+++ b/configure.ac
@@ -232,23 +232,11 @@ then
 fi
 
 # Determine XML2 include path
-AC_MSG_CHECKING(for libxml/xmlmemory.h)
-
-# Can we include headers using system include dirs?
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <libxml/xmlmemory.h>]], [[int a = 1;]])],[XML2_INCLUDE=" "],[XML2_INCLUDE=])
-
-# Hunt through several possible directories to find the includes for libxml2
-if test "x$XML2_INCLUDE" = "x"; then
-    old_CPPFLAGS="$CPPFLAGS"
-    for i in $xml2_include_dir /usr/include /usr/local/include /usr/include/libxml2 /usr/local/include/libxml2 ; do
-        CPPFLAGS="$old_CPPFLAGS -I$i"
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <libxml/xmlmemory.h>]], [[int a = 1;]])],[XML2_INCLUDE="-I$i"],[XML2_INCLUDE=
-        ])
-        if test "x$XML2_INCLUDE" != "x"; then
-            break;
-        fi
-    done
-    CPPFLAGS="$old_CPPFLAGS $XML2_INCLUDE"
+AC_CHECK_LIB([xml2], [xmlParseFile], [libxml2_found=yes])
+if test "$libxml2_found" = "yes" ; then
+    AC_DEFINE(HAVE_LIBXML2,1,[defined when libxml2 is available])
+else
+    AC_MSG_WARN([libxml2 not found. Disabling cache.])
 fi
 
 AC_CHECK_HEADERS([libxml/xmlmemory.h])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -394,44 +394,46 @@ noinst_HEADERS = cielab_luts.h \
                  v34_tx_pre_emphasis_filters.h \
                  v34_tables.h
 
-make_at_dictionary$(EXEEXT): $(top_srcdir)/src/make_at_dictionary.c
-	$(CC_FOR_BUILD) -o make_at_dictionary$(EXEEXT) $(top_srcdir)/src/make_at_dictionary.c -DHAVE_CONFIG_H -I$(top_builddir)/src
+LINK_FOR_BUILD.c = $(CC_FOR_BUILD) -DHAVE_CONFIG_H -I$(top_builddir)/src $(CFLAGS_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) $(TARGET_ARCH_FOR_BUILD)
 
-make_cielab_luts$(EXEEXT): $(top_srcdir)/src/make_cielab_luts.c
-	$(CC_FOR_BUILD) -o make_cielab_luts$(EXEEXT) $(top_srcdir)/src/make_cielab_luts.c -DHAVE_CONFIG_H -I$(top_builddir)/src -lm
+make_at_dictionary$(BUILD_EXEEXT): $(top_srcdir)/src/make_at_dictionary.c
+	$(LINK_FOR_BUILD.c) -o $@ $^
 
-make_math_fixed_tables$(EXEEXT): $(top_srcdir)/src/make_math_fixed_tables.c
-	$(CC_FOR_BUILD) -o make_math_fixed_tables$(EXEEXT) $(top_srcdir)/src/make_math_fixed_tables.c -DHAVE_CONFIG_H -I$(top_builddir)/src -lm
+make_cielab_luts$(BUILD_EXEEXT): $(top_srcdir)/src/make_cielab_luts.c
+	$(LINK_FOR_BUILD.c) -o $@ $^ -lm
 
-make_modem_filter$(EXEEXT): $(top_srcdir)/src/make_modem_filter.c $(top_srcdir)/src/filter_tools.c
-	$(CC_FOR_BUILD) -o make_modem_filter$(EXEEXT) $(top_srcdir)/src/make_modem_filter.c $(top_srcdir)/src/filter_tools.c -DHAVE_CONFIG_H -I$(top_builddir)/src -lm
+make_math_fixed_tables$(BUILD_EXEEXT): $(top_srcdir)/src/make_math_fixed_tables.c
+	$(LINK_FOR_BUILD.c) -o $@ $^ -lm
 
-make_modem_godard_descriptor$(EXEEXT): $(top_srcdir)/src/make_modem_godard_descriptor.c $(top_srcdir)/src/filter_tools.c
-	$(CC_FOR_BUILD) -o make_modem_godard_descriptor$(EXEEXT) $(top_srcdir)/src/make_modem_godard_descriptor.c $(top_srcdir)/src/filter_tools.c -DHAVE_CONFIG_H -I$(top_builddir)/src -lm
+make_modem_filter$(BUILD_EXEEXT): $(top_srcdir)/src/make_modem_filter.c $(top_srcdir)/src/filter_tools.c
+	$(LINK_FOR_BUILD.c) -o $@ $^ -lm
 
-make_t43_gray_code_tables$(EXEEXT): $(top_srcdir)/src/make_t43_gray_code_tables.c
-	$(CC_FOR_BUILD) -o make_t43_gray_code_tables$(EXEEXT) $(top_srcdir)/src/make_t43_gray_code_tables.c -DHAVE_CONFIG_H -I$(top_builddir)/src -lm
+make_modem_godard_descriptor$(BUILD_EXEEXT): $(top_srcdir)/src/make_modem_godard_descriptor.c $(top_srcdir)/src/filter_tools.c
+	$(LINK_FOR_BUILD.c) -o $@ $^ -lm
 
-make_v17_v32_constellation_map$(EXEEXT): $(top_srcdir)/src/make_v17_v32_constellation_map.c $(top_srcdir)/src/g711.c $(top_srcdir)/src/alloc.c
-	$(CC_FOR_BUILD) -o make_v17_v32_constellation_map$(EXEEXT) $(top_srcdir)/src/make_v17_v32_constellation_map.c $(top_srcdir)/src/g711.c $(top_srcdir)/src/alloc.c -DHAVE_CONFIG_H -I$(top_builddir)/src -lm
+make_t43_gray_code_tables$(BUILD_EXEEXT): $(top_srcdir)/src/make_t43_gray_code_tables.c
+	$(LINK_FOR_BUILD.c) -o $@ $^ -lm
 
-make_v17_v32_convolutional_encoder$(EXEEXT): $(top_srcdir)/src/make_v17_v32_convolutional_encoder.c $(top_srcdir)/src/g711.c $(top_srcdir)/src/alloc.c
-	$(CC_FOR_BUILD) -o make_v17_v32_convolutional_encoder$(EXEEXT) $(top_srcdir)/src/make_v17_v32_convolutional_encoder.c $(top_srcdir)/src/g711.c $(top_srcdir)/src/alloc.c -DHAVE_CONFIG_H -I$(top_builddir)/src -lm
+make_v17_v32_constellation_map$(BUILD_EXEEXT): $(top_srcdir)/src/make_v17_v32_constellation_map.c $(top_srcdir)/src/g711.c $(top_srcdir)/src/alloc.c
+	$(LINK_FOR_BUILD.c) -o $@ $^ -lm
 
-make_v29_constellation_map$(EXEEXT): $(top_srcdir)/src/make_v29_constellation_map.c $(top_srcdir)/src/g711.c $(top_srcdir)/src/alloc.c
-	$(CC_FOR_BUILD) -o make_v29_constellation_map$(EXEEXT) $(top_srcdir)/src/make_v29_constellation_map.c $(top_srcdir)/src/g711.c $(top_srcdir)/src/alloc.c -DHAVE_CONFIG_H -I$(top_builddir)/src -lm
+make_v17_v32_convolutional_encoder$(BUILD_EXEEXT): $(top_srcdir)/src/make_v17_v32_convolutional_encoder.c $(top_srcdir)/src/g711.c $(top_srcdir)/src/alloc.c
+	$(LINK_FOR_BUILD.c) -o $@ $^ -lm
 
-make_v34_convolutional_coders$(EXEEXT): $(top_srcdir)/src/make_v34_convolutional_coders.c
-	$(CC_FOR_BUILD) -o make_v34_convolutional_coders$(EXEEXT) $(top_srcdir)/src/make_v34_convolutional_coders.c -DHAVE_CONFIG_H -I$(top_builddir)/src -lm
+make_v29_constellation_map$(BUILD_EXEEXT): $(top_srcdir)/src/make_v29_constellation_map.c $(top_srcdir)/src/g711.c $(top_srcdir)/src/alloc.c
+	$(LINK_FOR_BUILD.c) -o $@ $^ -lm
 
-make_v34_probe_signals$(EXEEXT): $(top_srcdir)/src/make_v34_probe_signals.c $(top_srcdir)/src/g711.c $(top_srcdir)/src/alloc.c
-	$(CC_FOR_BUILD) -o make_v34_probe_signals$(EXEEXT) $(top_srcdir)/src/make_v34_probe_signals.c $(top_srcdir)/src/g711.c $(top_srcdir)/src/alloc.c -DHAVE_CONFIG_H -I$(top_builddir)/src -lm
+make_v34_convolutional_coders$(BUILD_EXEEXT): $(top_srcdir)/src/make_v34_convolutional_coders.c
+	$(LINK_FOR_BUILD.c) -o $@ $^ -lm
 
-make_v34_shell_map$(EXEEXT): $(top_srcdir)/src/make_v34_shell_map.c
-	$(CC_FOR_BUILD) -o make_v34_shell_map$(EXEEXT) $(top_srcdir)/src/make_v34_shell_map.c -DHAVE_CONFIG_H -I$(top_builddir)/src
+make_v34_probe_signals$(BUILD_EXEEXT): $(top_srcdir)/src/make_v34_probe_signals.c $(top_srcdir)/src/g711.c $(top_srcdir)/src/alloc.c
+	$(LINK_FOR_BUILD.c) -o $@ $^ -I$(top_srcdir)/src -lm
 
-make_v34_tx_pre_emphasis_filters$(EXEEXT): $(top_srcdir)/src/make_v34_tx_pre_emphasis_filters.c $(top_srcdir)/tools/meteor-engine.c
-	$(CC_FOR_BUILD) -o make_v34_tx_pre_emphasis_filters$(EXEEXT) $(top_srcdir)/src/make_v34_tx_pre_emphasis_filters.c $(top_srcdir)/tools/meteor-engine.c -DHAVE_CONFIG_H -I$(top_builddir)/src -I$(top_builddir)/tools -lm
+make_v34_shell_map$(BUILD_EXEEXT): $(top_srcdir)/src/make_v34_shell_map.c
+	$(LINK_FOR_BUILD.c) -o $@ $^
+
+make_v34_tx_pre_emphasis_filters$(BUILD_EXEEXT): $(top_srcdir)/src/make_v34_tx_pre_emphasis_filters.c $(top_srcdir)/tools/meteor-engine.c
+	$(LINK_FOR_BUILD.c) -o $@ $^ -I$(top_srcdir)/tools -lm
 
 # We need to run make_at_dictionary, so it generates the
 # at_interpreter_dictionary.h file


### PR DESCRIPTION
This is a rebase of the previous patches from Jörg Sommer in order to fix cross compilation and also make use of AC_CHECK_LIB while searching for libxml files.