### PR TITLE
Check for feenableexcept() explicitly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -173,6 +173,7 @@ fi
 AX_C99_FLEXIBLE_ARRAY
 
 AX_FUNC_ALIGNED_ALLOC
+AC_CHECK_FUNCS([feenableexcept])
 AC_CHECK_FUNCS([memalign])
 AC_CHECK_FUNCS([posix_memalign])
 AC_CHECK_FUNCS([memmove])
@@ -209,7 +210,6 @@ AC_CHECK_HEADERS([sys/select.h])
 AC_CHECK_HEADERS([sys/ioctl.h])
 AC_CHECK_HEADERS([sys/fcntl.h])
 AC_CHECK_HEADERS([sndfile.h])
-AC_CHECK_HEADERS([fenv.h])
 AC_CHECK_HEADERS([fftw3.h], , [AC_CHECK_HEADERS([fftw.h])])
 AC_CHECK_HEADERS([pcap.h])
 AC_CHECK_HEADERS([pthread.h])

--- a/tests/v17_tests.c
+++ b/tests/v17_tests.c
@@ -59,7 +59,7 @@ display of modem status is maintained.
 #include <string.h>
 #include <sndfile.h>
 #include <signal.h>
-#if defined(HAVE_FENV_H)
+#if defined(HAVE_FEENABLEEXCEPT)
 #define __USE_GNU
 #include <fenv.h>
 #endif
@@ -263,7 +263,7 @@ static void qam_report(void *user_data, const complexf_t *constel, const complex
 }
 /*- End of function --------------------------------------------------------*/
 
-#if defined(HAVE_FENV_H)
+#if defined(HAVE_FEENABLEEXCEPT)
 static void sigfpe_handler(int sig_num, siginfo_t *info, void *data)
 {
     switch (sig_num)
@@ -425,7 +425,7 @@ int main(int argc, char *argv[])
     inhandle = NULL;
     outhandle = NULL;
 
-#if defined(HAVE_FENV_H)
+#if defined(HAVE_FEENABLEEXCEPT)
     fpe_trap_setup();
 #endif
 

--- a/tests/v27ter_tests.c
+++ b/tests/v27ter_tests.c
@@ -58,7 +58,7 @@ display of modem status is maintained.
 #include <string.h>
 #include <sndfile.h>
 #include <signal.h>
-#if defined(HAVE_FENV_H)
+#if defined(HAVE_FEENABLEEXCEPT)
 #define __USE_GNU
 #include <fenv.h>
 #endif
@@ -286,7 +286,7 @@ static void qam_report(void *user_data, const complexf_t *constel, const complex
 }
 /*- End of function --------------------------------------------------------*/
 
-#if defined(HAVE_FENV_H)
+#if defined(HAVE_FEENABLEEXCEPT)
 static void sigfpe_handler(int sig_num, siginfo_t *info, void *data)
 {
     switch (sig_num)
@@ -440,7 +440,7 @@ int main(int argc, char *argv[])
     inhandle = NULL;
     outhandle = NULL;
 
-#if defined(HAVE_FENV_H)
+#if defined(HAVE_FEENABLEEXCEPT)
     fpe_trap_setup();
 #endif
 

--- a/tests/v29_tests.c
+++ b/tests/v29_tests.c
@@ -58,7 +58,7 @@ display of modem status is maintained.
 #include <string.h>
 #include <sndfile.h>
 #include <signal.h>
-#if defined(HAVE_FENV_H)
+#if defined(HAVE_FEENABLEEXCEPT)
 #define __USE_GNU
 #include <fenv.h>
 #endif
@@ -257,7 +257,7 @@ static void qam_report(void *user_data, const complexf_t *constel, const complex
 }
 /*- End of function --------------------------------------------------------*/
 
-#if defined(HAVE_FENV_H)
+#if defined(HAVE_FEENABLEEXCEPT)
 static void sigfpe_handler(int sig_num, siginfo_t *info, void *data)
 {
     switch (sig_num)
@@ -410,7 +410,7 @@ int main(int argc, char *argv[])
     inhandle = NULL;
     outhandle = NULL;
 
-#if defined(HAVE_FENV_H)
+#if defined(HAVE_FEENABLEEXCEPT)
     fpe_trap_setup();
 #endif
 


### PR DESCRIPTION
musl provides <fenv.h>, but not the non-standard feenableexcept() function, so using feenableexcept() whenever <fenv.h> was present caused build failures on musl.  Instead, explicitly check for the non-standard function we want to use.