### PR TITLE
Fix tests/pcap_parse build on musl

### DIFF
--- a/tests/pcap_parse.c
+++ b/tests/pcap_parse.c
@@ -31,7 +31,8 @@
 #include "config.h"
 #endif
 
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
+
 
 #include <inttypes.h>
 #include <stdlib.h>


### PR DESCRIPTION
musl only defines the Linux-style struct udphdr member names if _GNU_SOURCE is defined, so do that, like certain other tests already do.