### PR TITLE
tests: fix undefined behavior in `bit_operations_tests`

### DIFF
--- a/tests/bit_operations_tests.c
+++ b/tests/bit_operations_tests.c
@@ -288,19 +288,19 @@ int main(int argc, char *argv[])
     }
     /*endfor*/
 
-    for (i = -1;  i < 32;  i++)
+    for (i = 0;  i < 32;  i++)
     {
         ax32 = most_significant_one32(1U << i);
         if (ax32 != (1U << i))
         {
-            printf("Test failed: most significant one 32 - %x %" PRIx32 " %x\n", i, ax32, (1 << i));
+            printf("Test failed: most significant one 32 - %x %" PRIx32 " %x\n", i, ax32, (1U << i));
             exit(2);
         }
         /*endif*/
         ax32 = least_significant_one32(1U << i);
         if (ax32 != (1U << i))
         {
-            printf("Test failed: least significant one 32 - %x %" PRIx32 " %x\n", i, ax32, (1 << i));
+            printf("Test failed: least significant one 32 - %x %" PRIx32 " %x\n", i, ax32, (1U << i));
             exit(2);
         }
         /*endif*/


### PR DESCRIPTION
The `most_significant_one32`/`least_significant_one32` test loop started at `i = -1`, which produces a shift of `1U << -1`. This is undefined behavior per the C standard, as the shift count must be in `[0, bit_width)`. On x86 this happened to produce `0x80000000` due to masking the shift count to 5 bits, but on ppc64be it produces `0`, causing a spurious test failure.

This commit starts the loop at `i = 0` instead. Testing the zero-input case is not meaningful here since `most_significant_one32(0)` itself invokes UB internally (`1 << top_bit(0)` where `top_bit` returns `-1`). I've also fixed the printf format strings to use `1U` instead of `1` to avoid signed overflow when `i = 31`.