### PR TITLE
Fix buffer overrun in pseudoterminal test

### DIFF
--- a/tests/pseudo_terminals.c
+++ b/tests/pseudo_terminals.c
@@ -99,7 +99,7 @@ static char *make_message(const char *format, ...)
     va_start(arg_ptr, format);
     len = vsnprintf(NULL, 0, format, arg_ptr);
     va_end(arg_ptr);
-    if ((buf = malloc(len)) != NULL)
+    if ((buf = malloc(len + 1)) != NULL)
     {
         va_start(arg_ptr, format);
         vsprintf(buf, format, arg_ptr);


### PR DESCRIPTION
vsnprintf returns the number of bytes needed, *excluding* the terminating NUL byte.  This therefore always wrote the terminating NUL byte to one address past the end of buf.

Identified with fortify-headers.