### PR TITLE
Fix the issue where detection is not possible only when freq1 is used.

### DIFF
--- a/src/super_tone_rx.c
+++ b/src/super_tone_rx.c
@@ -309,10 +309,14 @@ static void super_tone_chunk(super_tone_rx_state_t *s)
     }
     else
     {
-        if (s->desc->monitored_frequencies < 2)
-        {
-            k1 =
-            k2 = 0;
+        if (s->desc->monitored_frequencies < 1) {
+            k1 = -1;
+            k2 = -1;
+        }
+        else if (s->desc->monitored_frequencies < 2) {
+            k1 = 0;
+            k2 = -1;
+            res[0] = goertzel_result(&s->state[0]);
         }
         else
         {


### PR DESCRIPTION
When only freq1 is configured and freq2 is set to zero, detection cannot be performed.
for example

> <configuration name="spandsp.conf">
    <descriptors debug-level="0">
        <descriptor name="cn">
            <tone name="BUSY_TONE">
                <element freq1="450" min="300" max="400" freq2="0"/>
                <element freq1="0" min="300" max="400" freq2="0"/>
                <element freq1="450" min="300" max="400" freq2="0"/>
                <element freq1="0" min="300" max="400" freq2="0"/>
                <element freq1="450" min="300" max="400" freq2="0"/>
            </tone>
        </descriptor>
    </descriptors>
</configuration>